### PR TITLE
Fix renderer playback; add Demozoo scene resolution + enrichment reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,20 @@ Run these from inside the SoniqBoom folder:
 
 | You want to… | Command |
 |--------------|---------|
+| **Start the server** | `bash startup.sh` (same as `bash run.sh`) |
 | **Change the port** (default is 8080) | `bash run.sh --port 9090` |
 | **Stop the server** | `bash shutdown.sh` |
 | **Restart the server** | `bash restart.sh` |
+| **Rebuild the retro-format players** | `bash install.sh --rebuild` |
+| **Delete the built-from-source players** | `bash install.sh --clean` |
 | **Create or reset your admin login** | `bash setup-admin.sh` |
 | Set an admin login non-interactively | `bash setup-admin.sh -user alice -passwd 'your-password'` |
 
 > Usernames are 2–64 characters (letters, digits, `.`, `_`, `-`); passwords are at least 8 characters. Add more people with `bash setup-admin.sh -user bob -passwd '…' -role readonly` (roles: `admin`, `edit`, `readonly`), or invite them from the admin UI once you're signed in. If the server is already running, the change takes effect right away (`setup-admin.sh` tells it to reload).
 
 > **`install.sh` sets up every renderer for you** — `sidplayfp` (SID), `fluidsynth` (MIDI), `libopenmpt` (trackers), `uade` (AHX), `libgme` (console chiptunes), and `adplay` (AdLib/OPL). If one ever fails to install, SoniqBoom names the exact missing package and everything else keeps working. (HivelyTracker `.hvl` needs nothing extra — it's bundled and compiled on first run.)
+>
+> If a player ever stops working after a system update, `bash install.sh --rebuild` rebuilds the players SoniqBoom compiles from source (the rest are managed by your package manager). `bash install.sh --clean` just removes them, and `bash install.sh --help` lists all the options. On startup SoniqBoom also checks every player and logs a one-line health summary, so a broken one is easy to spot.
 
 ---
 

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -28,7 +28,7 @@ or include their source code.
 | Tool | License | Usage |
 |------|---------|-------|
 | [FFmpeg](https://ffmpeg.org/) | LGPL-2.1 / GPL-2.0 (depending on build configuration) | Audio transcoding and format conversion. Invoked via subprocess for on-the-fly audio stream delivery. |
-| [libsidplayfp / sidplayfp](https://github.com/libsidplayfp/sidplayfp) | GPL-2.0 | Commodore 64 SID music emulation and playback. Invoked via subprocess to render SID files to audio. |
+| [libresidfp / libsidplayfp / sidplayfp](https://github.com/libsidplayfp/sidplayfp) | GPL-2.0-or-later | Commodore 64 SID music emulation and playback (accurate reSIDfp engine). Built from upstream source by install.sh (libresidfp → libsidplayfp → sidplayfp CLI, since Homebrew's libsidplayfp ships only the lighter `sidlite` engine) with the library closure bundled locally via `@loader_path` so a `brew upgrade` can't orphan it. Invoked via subprocess to render SID files to audio. |
 | [FluidSynth](https://github.com/FluidSynth/fluidsynth) | LGPL-2.1 | Software MIDI synthesizer. Invoked via subprocess to render MIDI files to audio using SoundFont banks. |
 | [libopenmpt / openmpt123](https://lib.openmpt.org/libopenmpt/) | BSD-3-Clause | Tracker module file playback (MOD, XM, S3M, IT, etc.). Invoked via subprocess to render module files to audio. |
 | [UADE / uade123](https://zakalwe.fi/uade/) | GPL-2.0 | Exotic Amiga music formats (AHX, TFMX, Future Composer, SidMon, and ~150 others) via emulated original Amiga player code. Invoked via subprocess. |

--- a/install.sh
+++ b/install.sh
@@ -15,8 +15,138 @@ warn()    { echo -e "${YELLOW}⚠ $*${NC}"; }
 section() { echo -e "\n${BOLD}── $* ──${RESET}"; }
 die()     { echo -e "${RED}✗ $*${NC}" >&2; exit 1; }
 
+# ── Self-contained bundling (macOS) ──────────────────────────────────────────
+# From-source renderers (zxtune123, sidplayfp) link Homebrew dylibs dynamically,
+# so a later `brew upgrade` can orphan them (dyld "Symbol not found" / "Library
+# not loaded").  These copy a binary's full non-system dylib closure next to it
+# and repoint every reference to @loader_path, so it carries its own libs and no
+# future upgrade can break it.  Call _bundle_selfcontained with errexit+nounset
+# OFF (the array/otool/grep plumbing legitimately returns non-zero).
+_deps_src(){  # <macho> -> absolute SOURCE paths of bundle-worthy deps (resolves @loader_path)
+  local f="$1" dir; dir="$(cd "$(dirname "$f")" 2>/dev/null && pwd)"
+  otool -L "$f" | awk '/\(compatibility version/{print $1}' | while read -r p; do
+    case "$p" in
+      /usr/lib/*|/System/*|"") ;;                          # system: skip
+      @loader_path/*) echo "$dir/${p#@loader_path/}" ;;    # sibling: resolve to abs
+      @rpath/*|@executable_path/*) ;;                       # unsupported: leak-check catches
+      /*) echo "$p" ;;                                      # absolute non-system: include
+    esac
+  done
+}
+_bundle_selfcontained(){  # <src_binary> <dest_dir>; non-zero on leak/missing dep
+  local src="$1" dest="$2" base; base="$(basename "$src")"
+  mkdir -p "$dest"; cp "$src" "$dest/$base"; chmod u+w "$dest/$base"
+  local -a todo closure=(); todo=($(_deps_src "$src"))
+  while [ "${#todo[@]}" -gt 0 ]; do
+    local dep="${todo[0]}"; todo=("${todo[@]:1}")
+    case " ${closure[*]} " in *" $dep "*) continue;; esac
+    [ -f "$dep" ] || { warn "  bundle: dep not found: $dep"; continue; }
+    closure+=("$dep"); todo+=($(_deps_src "$dep"))
+  done
+  local dep b f p
+  for dep in "${closure[@]}"; do                            # copy each in; clean @loader_path id
+    b="$(basename "$dep")"; cp "$dep" "$dest/$b"; chmod u+w "$dest/$b"
+    install_name_tool -id "@loader_path/$b" "$dest/$b" 2>/dev/null
+  done
+  for f in "$dest/$base" "$dest"/*.dylib; do                # repoint absolute non-system deps
+    [ -e "$f" ] || continue
+    for p in $(otool -L "$f" | awk '/\(compatibility version/{print $1}' | grep -E '^/' | grep -vE '^/usr/lib/|^/System/'); do
+      install_name_tool -change "$p" "@loader_path/$(basename "$p")" "$f" 2>/dev/null
+    done
+  done
+  for f in "$dest/$base" "$dest"/*.dylib; do codesign --force --sign - "$f" >/dev/null 2>&1; done
+  local leak=""                                             # falsifiable self-containment check
+  for f in "$dest"/*; do
+    for p in $(otool -L "$f" | awk '/\(compatibility version/{print $1}'); do
+      case "$p" in
+        /usr/lib/*|/System/*|"") ;;
+        @loader_path/*) [ -f "$dest/${p#@loader_path/}" ] || leak="$leak ${p}[missing]" ;;
+        *) leak="$leak $p" ;;
+      esac
+    done
+  done
+  [ -z "${leak// /}" ] || { warn "  bundle: unbundled refs remain:$leak"; return 1; }
+  return 0
+}
+_install_selfcontained(){  # <stage_dir> <dest_bin_dir>: install binary+dylibs, root-owned-safe
+  local stage="$1" dest="$2" sudo=""
+  [ -w "$dest" ] || sudo="sudo"
+  if [ -n "$sudo" ] && ! command -v sudo &>/dev/null; then
+    warn "cannot write $dest — copy $stage/* there by hand"; return 1
+  fi
+  $sudo cp "$stage"/* "$dest/" || { warn "could not install to $dest"; return 1; }
+}
+
+# ── Renderer cleanup (--clean / --rebuild) ───────────────────────────────────
+# Remove ONLY the renderers install.sh built from source (real files in the
+# install prefix) + their bundled @loader_path dylib closure + the build-on-first-
+# use helpers.  A Homebrew-managed player is a symlink into the Cellar — brew owns
+# it, so we skip it (the operator uses `brew reinstall <name>`).  Call with
+# errexit+nounset OFF (array/otool/grep plumbing).
+_clean_bundled_siblings(){  # <binary> <dir>: rm the binary's transitive @loader_path dylibs
+  command -v otool >/dev/null 2>&1 || return 0
+  local bin="$1" dir="$2"
+  local -a todo seen=()
+  todo=($(otool -L "$bin" 2>/dev/null | awk '/\(compatibility version/{print $1}' | sed -n 's#^@loader_path/##p'))
+  while [ "${#todo[@]}" -gt 0 ]; do
+    local n="${todo[0]}"; todo=("${todo[@]:1}")
+    case " ${seen[*]} " in *" $n "*) continue;; esac
+    [ -f "$dir/$n" ] || continue
+    seen+=("$n")
+    todo+=($(otool -L "$dir/$n" 2>/dev/null | awk '/\(compatibility version/{print $1}' | sed -n 's#^@loader_path/##p' | grep -vFx "$n"))
+  done
+  local n; for n in "${seen[@]}"; do rm -f "$dir/$n"; done
+}
+_clean_renderers(){
+  local bindir removed=0 name bin
+  bindir="$(brew --prefix 2>/dev/null || echo /usr/local)/bin"
+  for name in zxtune123 sidplayfp psgplay uade123 sc68; do
+    bin="$bindir/$name"
+    if [ -L "$bin" ]; then
+      warn "  $name is Homebrew-managed (symlink) — skipping (use 'brew reinstall $name')"
+    elif [ -f "$bin" ]; then
+      _clean_bundled_siblings "$bin" "$bindir"
+      rm -f "$bin" && { info "  removed $name + bundled libs"; removed=$((removed + 1)); }
+    fi
+  done
+  for name in ym2wav hvl2wav; do
+    if [ -f "$DATA_DIR/native/$name" ]; then
+      rm -f "$DATA_DIR/native/$name" && { info "  removed $name (rebuilds on first play)"; removed=$((removed + 1)); }
+    fi
+  done
+  info "cleaned $removed renderer artifact(s)"
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV="$SCRIPT_DIR/.venv"
+
+# ── CLI options ──────────────────────────────────────────────────────────────
+MODE=install
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --clean)   MODE=clean ;;
+    --rebuild) MODE=rebuild ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: install.sh [--clean | --rebuild | --help]
+
+  (no option)   Install/update SoniqBoom and its renderers (idempotent —
+                already-present renderers are left as-is).
+  --rebuild     Delete the from-source renderers, then run the install so they
+                are rebuilt from scratch.
+  --clean       Delete the from-source renderers and exit (no install).
+  --help        Show this message.
+
+--clean/--rebuild affect ONLY the renderers install.sh builds from source —
+zxtune123, sidplayfp, psgplay (+ their bundled libraries) and the build-on-first-
+use ym2wav/hvl2wav.  Homebrew-managed players (fluidsynth, openmpt123, adplay,
+sc68, uade123) are left untouched; use `brew reinstall <name>` to rebuild those.
+EOF
+      exit 0 ;;
+    *) warn "unknown option: $1 (try --help)" ;;
+  esac
+  shift
+done
 
 OS_KIND="$(uname -s)"
 case "$OS_KIND" in
@@ -25,6 +155,26 @@ case "$OS_KIND" in
   *)      die "Unsupported platform: $OS_KIND.  SoniqBoom targets macOS and Linux." ;;
 esac
 info "Detected platform: ${PLATFORM}"
+
+# Data dir (mirrors run.sh) — where the build-on-first-use helpers live.
+if [ -n "${SONIQBOOM_DATA_DIR:-}" ]; then
+  DATA_DIR="$SONIQBOOM_DATA_DIR"
+elif [ "$PLATFORM" = "macos" ]; then
+  DATA_DIR="$HOME/Library/Application Support/SoniqBoom"
+else
+  DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/soniqboom"
+fi
+
+# --clean / --rebuild: wipe the from-source renderers up front.  --clean stops
+# here; --rebuild falls through into the normal install, which rebuilds them.
+if [ "$MODE" = clean ] || [ "$MODE" = rebuild ]; then
+  section "Removing from-source renderers (--$MODE)"
+  set +eu; _clean_renderers; set -eu
+  if [ "$MODE" = clean ]; then
+    info "Clean complete.  Run './install.sh' (or './install.sh --rebuild') to rebuild."
+    exit 0
+  fi
+fi
 
 # ── Pre-flight: tools we assume are already present ──────────────────────────
 # On Linux we build a couple of players from source (git clone + make), and git
@@ -82,22 +232,57 @@ if [ "$PLATFORM" = "macos" ]; then
   fi
   info "ffmpeg (system): $(ffmpeg -version 2>&1 | head -1)"
 
-  if ! command -v sidplayfp &>/dev/null; then
-    info "Installing libsidplayfp library…"
-    brew install libsidplayfp
-    brew install pkgconf 2>/dev/null || true
-
-    SIDPLAYFP_VER="2.16.2"
-    info "Building sidplayfp CLI player v${SIDPLAYFP_VER} from source…"
-    TMPBUILD="$(mktemp -d)"
-    curl -sL "https://github.com/libsidplayfp/sidplayfp/releases/download/v${SIDPLAYFP_VER}/sidplayfp-${SIDPLAYFP_VER}.tar.gz" \
-      -o "$TMPBUILD/sidplayfp.tar.gz"
-    tar xzf "$TMPBUILD/sidplayfp.tar.gz" -C "$TMPBUILD"
-    (cd "$TMPBUILD/sidplayfp-${SIDPLAYFP_VER}" && \
-      ./configure --prefix="$(brew --prefix)" --quiet && \
-      make -j"$(sysctl -n hw.ncpu)" --quiet && \
-      make install --quiet)
-    rm -rf "$TMPBUILD"
+  # sidplayfp (C64 SID) — built from source with the accurate reSIDfp engine.
+  # Homebrew's libsidplayfp 3.x ships ONLY the lightweight `sidlite` engine
+  # (reSIDfp was split into an external libresidfp that has no brew formula), and
+  # a from-source binary linking Homebrew's rolling libsidplayfp gets orphaned by
+  # the next `brew upgrade libsidplayfp` (dyld "Library not loaded").  So build the
+  # whole chain — libresidfp → libsidplayfp(+reSIDfp) → sidplayfp CLI — into a
+  # private prefix and bundle its dylib closure via @loader_path
+  # (_bundle_selfcontained).  All three are GPL-2.0-or-later, used at arm's length
+  # (subprocess) and built from upstream source, so SoniqBoom's AGPL-3.0 is
+  # unaffected.  The --version probe re-heals a present-but-orphaned binary.
+  if command -v sidplayfp &>/dev/null && sidplayfp --version &>/dev/null; then
+    info "sidplayfp already installed: $(command -v sidplayfp)"
+  else
+    BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
+    RESIDFP_VER="1.2.2"; LIBSID_VER="3.1.0"; SIDCLI_VER="3.1.0"
+    if [ -z "$BREW_PREFIX" ]; then
+      warn "sidplayfp: brew unavailable — skipping (SID disabled)"
+    else
+      brew install pkgconf 2>/dev/null || true
+      SID_TMP="$(mktemp -d)"; SID_PREFIX="$SID_TMP/prefix"; mkdir -p "$SID_PREFIX"
+      SID_PKGCONF="$SID_PREFIX/lib/pkgconfig:$BREW_PREFIX/lib/pkgconfig"
+      info "Building the accurate SID chain (libresidfp→libsidplayfp→sidplayfp, ~2-3 min)…"
+      _sid_lib(){  # <url> <subdir> <log>: fetch + configure + make + make install
+        curl -sfL "$1" -o "$SID_TMP/s.tgz" && tar xzf "$SID_TMP/s.tgz" -C "$SID_TMP" \
+          && ( cd "$SID_TMP/$2" && PKG_CONFIG_PATH="$SID_PKGCONF" ./configure --prefix="$SID_PREFIX" --quiet \
+               && make -j"$(sysctl -n hw.ncpu)" && make install ) >"$SID_TMP/$3" 2>&1
+      }
+      if _sid_lib "https://github.com/libsidplayfp/libresidfp/releases/download/v${RESIDFP_VER}/libresidfp-${RESIDFP_VER}.tar.gz" "libresidfp-${RESIDFP_VER}" "1_residfp.log" \
+         && _sid_lib "https://github.com/libsidplayfp/libsidplayfp/releases/download/v${LIBSID_VER}/libsidplayfp-${LIBSID_VER}.tar.gz" "libsidplayfp-${LIBSID_VER}" "2_libsid.log" \
+         && curl -sfL "https://github.com/libsidplayfp/sidplayfp/releases/download/v${SIDCLI_VER}/sidplayfp-${SIDCLI_VER}.tar.gz" -o "$SID_TMP/cli.tgz" \
+         && tar xzf "$SID_TMP/cli.tgz" -C "$SID_TMP" \
+         && ( cd "$SID_TMP/sidplayfp-${SIDCLI_VER}" && PKG_CONFIG_PATH="$SID_PKGCONF" ./configure --prefix="$SID_PREFIX" --quiet \
+              && make -j"$(sysctl -n hw.ncpu)" ) >"$SID_TMP/3_cli.log" 2>&1; then
+        SIDBIN="$(find "$SID_TMP/sidplayfp-${SIDCLI_VER}" -name sidplayfp -type f -perm -u+x -print -quit 2>/dev/null)"
+        SID_STAGE="$SID_TMP/stage"
+        if [ -n "$SIDBIN" ] && [ -x "$SIDBIN" ]; then
+          set +eu; _bundle_selfcontained "$SIDBIN" "$SID_STAGE"; _sid_ok=$?; set -eu
+          if [ "$_sid_ok" -eq 0 ] && "$SID_STAGE/sidplayfp" --version >/dev/null 2>&1; then
+            _install_selfcontained "$SID_STAGE" "$BREW_PREFIX/bin" || true
+          else
+            warn "sidplayfp self-contained bundling failed — see $SID_TMP (SID disabled)"
+          fi
+        else
+          warn "sidplayfp CLI build produced no binary — see $SID_TMP/3_cli.log (SID disabled)"
+        fi
+      else
+        warn "sidplayfp chain build failed — see $SID_TMP/*.log (SID disabled)"
+      fi
+      # Clean up only on a verified-working install (keep logs for diagnosis otherwise).
+      command -v sidplayfp &>/dev/null && sidplayfp --version &>/dev/null && rm -rf "$SID_TMP"
+    fi
   fi
   info "sidplayfp: $(command -v sidplayfp || echo 'not found')"
 
@@ -481,7 +666,7 @@ case "$(uname -m)" in
   *)             ZXARCH="" ;;
 esac
 ZXTUNE_LINUX_URL="https://storage.zxtune.ru/builds/public/r5100/linux/${ZXARCH}/zxtune_r5100_linux_${ZXARCH}.tar.gz"
-if command -v zxtune123 &>/dev/null; then
+if command -v zxtune123 &>/dev/null && zxtune123 --version &>/dev/null; then
   info "zxtune123 already installed: $(command -v zxtune123)"
 elif [ "$PLATFORM" = "linux" ] && [ -n "$ZXARCH" ]; then
   ZX_TMP="$(mktemp -d)"
@@ -496,22 +681,44 @@ elif [ "$PLATFORM" = "linux" ] && [ -n "$ZXARCH" ]; then
   info "zxtune123: $(command -v zxtune123 || echo 'not installed — PSF/USF/GSF/… disabled')"
 elif [ "$PLATFORM" = "macos" ]; then
   warn "Building zxtune123 from source (one-time, ~10-15 min; needs boost)…"
-  brew list boost &>/dev/null || brew install boost
+  brew list boost &>/dev/null || brew install boost || true
   ZX_TMP="$(mktemp -d)"
-  if git clone -q https://github.com/vitamin-caig/zxtune.git "$ZX_TMP/zxtune" \
+  # Capture brew paths defensively — a failed `brew install boost` or `brew --prefix`
+  # must skip this OPTIONAL section, not abort the whole installer (set -e).
+  BREW_BOOST="$(brew --prefix boost 2>/dev/null || true)"
+  BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
+  if [ -z "$BREW_BOOST" ] || [ -z "$BREW_PREFIX" ]; then
+    warn "zxtune123: boost/brew unavailable — skipping (PSF/USF/GSF/… disabled)"
+    rm -rf "$ZX_TMP"
+  elif git clone -q https://github.com/vitamin-caig/zxtune.git "$ZX_TMP/zxtune" \
       && git -C "$ZX_TMP/zxtune" checkout -q "$ZXTUNE_REV"; then
     ( cd "$ZX_TMP/zxtune" \
       && sed -i '' 's/if (!subLocation\.unique())/if (subLocation.use_count() != 1)/; s/if (!Subdata\.unique())/if (Subdata.use_count() != 1)/' src/core/plugins/archives/raw_supp.cpp \
       && sed -i '' 's/#    define FMT_CONSTEVAL consteval/#    define FMT_CONSTEVAL/' 3rdparty/fmt/include/fmt/core.h \
-      && env CPATH="$(brew --prefix boost)/include" LIBRARY_PATH="$(brew --prefix boost)/lib" \
+      && env CPATH="$BREW_BOOST/include" LIBRARY_PATH="$BREW_BOOST/lib" \
          make system.zlib=1 platform=darwin -C apps/zxtune123 -j"$(sysctl -n hw.ncpu)" ) \
-      >/dev/null 2>&1 || true
+      >"$ZX_TMP/build.log" 2>&1 || true
     ZXBIN="$ZX_TMP/zxtune/bin/darwin/release/zxtune123"
     if [ -x "$ZXBIN" ]; then
-      cp "$ZXBIN" "$(brew --prefix)/bin/zxtune123"
+      # Make the build self-contained so a later `brew upgrade boost` can't orphan
+      # it (boost 1.92 relocated program_options::arg into detail:: — renaming the
+      # exported symbol — and every earlier build stopped loading).  boost is
+      # BSL-1.0 and these are the user's own local dylibs, so bundling is fine.
+      # errexit/nounset off around the bundler (its otool/grep plumbing returns 1).
+      STAGE="$ZX_TMP/stage"
+      set +eu; _bundle_selfcontained "$ZXBIN" "$STAGE"; _ok=$?; set -eu
+      if [ "$_ok" -eq 0 ] && "$STAGE/zxtune123" --version >/dev/null 2>&1; then
+        _install_selfcontained "$STAGE" "$BREW_PREFIX/bin" || true
+      else
+        warn "zxtune123 self-contained bundling failed — see $ZX_TMP/build.log (PSF/USF/GSF/… disabled)"
+      fi
+    else
+      warn "zxtune123 build failed — see $ZX_TMP/build.log"
     fi
   fi
-  rm -rf "$ZX_TMP"
+  # Keep the temp tree (and build.log) on failure; clean up only on a verified-
+  # working install (mirrors sidplayfp — a rebuild-over-orphan failure keeps its log).
+  command -v zxtune123 &>/dev/null && zxtune123 --version &>/dev/null && rm -rf "$ZX_TMP"
   info "zxtune123: $(command -v zxtune123 || echo 'build failed — PSF/USF/GSF/… disabled (re-run install.sh to retry)')"
 else
   warn "zxtune123: no prebuilt for this platform — PSF-family formats disabled"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "soniqboom"
-version = "1.8.1"
+version = "1.9.0"
 description = "Self-hosted music server for personal libraries — FLAC, MP3, Opus, SID, MIDI, plus 20+ tracker formats"
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/run.sh
+++ b/run.sh
@@ -40,6 +40,13 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Mount-safe "is the port busy?" probe.  A localhost /dev/tcp connect only ever
+# touches the loopback stack, so — unlike `lsof` — it can NOT block on a stale
+# network mount (SMB/NFS/FTP fd).  That deadlock used to wedge this start script
+# in its port pre-check, before the server ever launched.  True (0) iff
+# something is accepting on PORT (the server binds 0.0.0.0, which 127.0.0.1 hits).
+_port_busy() { (exec 3<>"/dev/tcp/127.0.0.1/${PORT}") 2>/dev/null; }
+
 # ── Pre-flight ───────────────────────────────────────────────────────────────
 if [ ! -f "$SONIQBOOM" ]; then
   echo -e "${RED}SoniqBoom not installed. Run: bash install.sh${NC}"
@@ -68,18 +75,29 @@ fi
 # process).  Without this, we'd launch a second process that fails to bind and
 # dies — and the readiness check below would then falsely succeed against the
 # incumbent, reporting "ready" while the new code never ran.  ``shutdown.sh``'s
-# port fallback can clear an orphan.  Degrades to no-op if lsof is unavailable.
-if command -v lsof &>/dev/null; then
-  PORT_HOLDER=$(lsof -ti "TCP:${PORT}" -sTCP:LISTEN 2>/dev/null | head -1 || true)
-  if [ -n "$PORT_HOLDER" ]; then
-    echo ""
-    echo -e "${BOLD}── SoniqBoom ──${RESET}"
-    echo ""
-    echo -e "  ${RED}Port ${PORT} is already in use (pid ${PORT_HOLDER}).${NC}"
-    echo -e "  Run ${BOLD}bash shutdown.sh${RESET} first, or start with ${BOLD}--port <number>${RESET}."
-    echo ""
-    exit 1
+# port fallback can clear an orphan.
+#
+# Detection uses the mount-safe _port_busy probe, NOT lsof — lsof can deadlock
+# on a stale network-mount fd, which used to hang this start indefinitely before
+# the server launched.  lsof is used only to NAME the holder in the message, and
+# is bounded with -S so it can't block; if it's absent or times out we still
+# refuse to start, just without the pid.
+if _port_busy; then
+  PORT_HOLDER=""
+  if command -v lsof &>/dev/null; then
+    PORT_HOLDER=$(lsof -S 5 -ti "TCP:${PORT}" -sTCP:LISTEN 2>/dev/null | head -1 || true)
   fi
+  echo ""
+  echo -e "${BOLD}── SoniqBoom ──${RESET}"
+  echo ""
+  if [ -n "$PORT_HOLDER" ]; then
+    echo -e "  ${RED}Port ${PORT} is already in use (pid ${PORT_HOLDER}).${NC}"
+  else
+    echo -e "  ${RED}Port ${PORT} is already in use.${NC}"
+  fi
+  echo -e "  Run ${BOLD}bash shutdown.sh${RESET} first, or start with ${BOLD}--port <number>${RESET}."
+  echo ""
+  exit 1
 fi
 
 # ── First-run admin bootstrap ────────────────────────────────────────────────

--- a/shutdown.sh
+++ b/shutdown.sh
@@ -29,6 +29,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Mount-safe "is the port busy?" probe.  A localhost /dev/tcp connect only ever
+# touches the loopback stack, so — unlike `lsof` — it can NOT block on a stale
+# network mount (SMB/NFS/FTP fd), which is the exact deadlock that used to wedge
+# this whole script on a restart.  True (0) iff something is accepting on PORT.
+_port_busy() { (exec 3<>"/dev/tcp/127.0.0.1/${PORT}") 2>/dev/null; }
+
 # ── Find the process ─────────────────────────────────────────────────────────
 PID=""
 
@@ -60,8 +66,11 @@ fi
 # or whether the pidfile/argv match.  Guarded so we only adopt a Python /
 # soniqboom process and never kill an unrelated app that happens to hold the
 # port.  Degrades safely if lsof is unavailable.
-if [ -z "$PID" ]; then
-  PORT_PID=$(lsof -ti "TCP:${PORT}" -sTCP:LISTEN 2>/dev/null | head -1 || true)
+if [ -z "$PID" ] && _port_busy; then
+  # -S bounds lsof's per-fd kernel stat calls so a stale network mount can't
+  # deadlock the lookup; gated on _port_busy so we skip lsof entirely when the
+  # port is already free (nothing to find).
+  PORT_PID=$(lsof -S 5 -ti "TCP:${PORT}" -sTCP:LISTEN 2>/dev/null | head -1 || true)
   if [ -n "$PORT_PID" ]; then
     PORT_CMD=$(ps -p "$PORT_PID" -o command= 2>/dev/null || true)
     case "$PORT_CMD" in
@@ -108,32 +117,37 @@ pkill -f 'soniqboom-menubar\.py' 2>/dev/null || true
 # follow-up start (or ``restart.sh``) report "port already in use".  So don't
 # return until the port is actually released: terminate any lingering
 # *SoniqBoom* listener still on it (an unrelated process is left untouched).
-if command -v lsof &>/dev/null; then
-  for i in $(seq 1 30); do
-    HOLDER=$(lsof -ti "TCP:${PORT}" -sTCP:LISTEN 2>/dev/null | head -1 || true)
-    if [ -z "$HOLDER" ]; then break; fi
-    HCMD=$(ps -p "$HOLDER" -o command= 2>/dev/null || true)
-    case "$HCMD" in
-      *soniqboom*)
-        if [ "$i" -le 5 ]; then
-          kill -TERM "$HOLDER" 2>/dev/null || true
-        else
-          kill -9 "$HOLDER" 2>/dev/null || true
-        fi ;;
-      *)
-        echo -e "  ${RED}Port ${PORT} is held by a non-SoniqBoom process (pid ${HOLDER}) — leaving it alone.${NC}"
-        break ;;
-    esac
-    sleep 1
-  done
-  HOLDER=$(lsof -ti "TCP:${PORT}" -sTCP:LISTEN 2>/dev/null | head -1 || true)
-  if [ -n "$HOLDER" ]; then
-    echo -e "  ${RED}⚠  Port ${PORT} is still in use (pid ${HOLDER}) — a restart may fail to bind.${NC}"
-  else
-    echo -e "  ${GREEN}✓${NC} SoniqBoom stopped; port ${PORT} is free."
+#
+# Readiness is decided by the mount-safe _port_busy probe, NOT by lsof — the
+# common case (target exited, port already free) returns instantly without ever
+# calling lsof.  lsof is invoked ONLY to identify+kill a genuine lingering
+# listener, and is bounded with -S so a stale network-mount fd can't deadlock it
+# (the bug that used to hang this script forever on a restart).
+for i in $(seq 1 30); do
+  _port_busy || break                       # port free → done (no lsof needed)
+  if command -v lsof &>/dev/null; then
+    HOLDER=$(lsof -S 5 -ti "TCP:${PORT}" -sTCP:LISTEN 2>/dev/null | head -1 || true)
+    if [ -n "$HOLDER" ]; then
+      HCMD=$(ps -p "$HOLDER" -o command= 2>/dev/null || true)
+      case "$HCMD" in
+        *soniqboom*)
+          if [ "$i" -le 5 ]; then
+            kill -TERM "$HOLDER" 2>/dev/null || true
+          else
+            kill -9 "$HOLDER" 2>/dev/null || true
+          fi ;;
+        *)
+          echo -e "  ${RED}Port ${PORT} is held by a non-SoniqBoom process (pid ${HOLDER}) — leaving it alone.${NC}"
+          break ;;
+      esac
+    fi
   fi
+  sleep 1
+done
+if _port_busy; then
+  echo -e "  ${RED}⚠  Port ${PORT} is still in use — a restart may fail to bind.${NC}"
 else
-  echo -e "  ${GREEN}✓${NC} SoniqBoom stopped."
+  echo -e "  ${GREEN}✓${NC} SoniqBoom stopped; port ${PORT} is free."
 fi
 LAST=$(grep -i 'shutdown\|snapshot\|stopped' "$LOG_FILE" 2>/dev/null | tail -1 || true)
 [ -n "$LAST" ] && echo -e "  ${DIM}$LAST${NC}"

--- a/soniqboom/__init__.py
+++ b/soniqboom/__init__.py
@@ -9,7 +9,7 @@ streamed from your network to any device with a browser.
 Source:  https://github.com/SFCyris/SoniqBoom
 License: AGPL-3.0-or-later
 """
-__version__ = "1.8.1"
+__version__ = "1.9.0"
 __author__  = "S.F. Cyris"
 __license__ = "AGPL-3.0-or-later"
 __url__     = "https://github.com/SFCyris/SoniqBoom"

--- a/soniqboom/api/admin.py
+++ b/soniqboom/api/admin.py
@@ -178,9 +178,39 @@ async def admin_demozoo_refresh(_tok: str = Depends(_require_token)):
 async def admin_demozoo_apply(_tok: str = Depends(_require_token)):
     """Match every retro track's composer (``artist``) against the Demozoo
     index and fill in ``scene_group`` (real-name + handle, confidence-gated —
-    ambiguous names are skipped).  Join in an executor; store WRITE on the loop."""
+    ambiguous names are skipped).  Join in an executor; store WRITE on the loop.
+    Re-enables post-scan auto-apply (an explicit Apply opts back in)."""
     from soniqboom.core import demozoo
+    demozoo.set_auto_apply(True)
     return await demozoo.apply_to_library()
+
+
+@router.post("/demozoo/reset")
+async def admin_demozoo_reset(_tok: str = Depends(_require_token)):
+    """Withdraw the Demozoo scene enrichment — the release-year backfill,
+    ``scene_group``, and auto-filled ``composer`` — undoing ``/demozoo/apply``.
+    The user's own hand-edits are preserved.  Scoped to the Demozoo layer: the
+    separate Modland artist/``scene_path`` fill (``/scene/apply``) is left in
+    place.  Turns OFF post-scan auto-apply so the reset HOLDS across scans (the
+    Apply button, or the auto-apply toggle, turns it back on).  Collect in an
+    executor, store WRITE on the loop."""
+    from soniqboom.core import demozoo
+    demozoo.set_auto_apply(False)
+    return await demozoo.reset_to_file_state()
+
+
+@router.post("/demozoo/auto-apply")
+async def admin_demozoo_auto_apply(body: dict, _tok: str = Depends(_require_token)):
+    """Enable/disable re-running the Demozoo apply automatically after a library
+    scan.  ``{"enabled": bool}``.  Returns the updated status."""
+    from soniqboom.core import demozoo
+    raw = body.get("enabled", True)
+    # Coerce safely: a JSON string like "false"/"0" is truthy under bool(), so
+    # interpret non-bool inputs explicitly rather than silently enabling.
+    enabled = raw if isinstance(raw, bool) else \
+        str(raw).strip().lower() in ("true", "1", "yes", "on")
+    demozoo.set_auto_apply(enabled)
+    return demozoo.status()
 
 
 @router.post("/verify-indexes")
@@ -1687,6 +1717,93 @@ def _resolve_ftp_share_from_body(body: dict, conf: dict) -> dict | None:
 
 # ── Renderers ────────────────────────────────────────────────────────────────
 
+# Exec-probeable plain-binary renderers: (key, settings.<attr>).  Shared by the
+# admin panel (below) and the startup health probe (main.py) so both agree on
+# what "present but broken" means.  ffmpeg has its own richer feature-probe; gme
+# is an in-process libgme binding; ym2wav/hvl2wav build on first use — none has a
+# standalone binary to exec here.
+_PROBE_RENDERER_SPECS = (
+    ("sidplayfp", "sidplayfp_path"), ("fluidsynth", "fluidsynth_path"),
+    ("openmpt123", "openmpt123_path"), ("uade123", "uade123_path"),
+    ("adplay", "adplay_path"), ("psgplay", "psgplay_path"),
+    ("sc68", "sc68_path"), ("zxtune123", "zxtune123_path"),
+)
+
+
+async def probe_renderer_runs(path: str) -> bool | None:
+    """Does the binary actually LOAD and start?  ``installed`` only means the
+    file is present — a prebuilt/from-source binary whose shared libs were
+    upgraded out from under it (e.g. Homebrew bumped boost under a from-source
+    zxtune123 → dyld symbol-not-found abort) still passes ``is_file()``.  Exec the
+    binary and watch for a dynamic-LOADER failure (aborted before it ran → killed
+    by a signal / negative returncode, or a loader banner on stderr).  A plain
+    non-zero exit (a tool with no ``--version`` printing usage) still means it
+    LOADED → True.  ``None`` when there's nothing to probe.  MUST use
+    ``create_subprocess_exec`` — ``subprocess.run`` fork()s unsafely from a
+    Core-Foundation process on macOS (see the ffmpeg probe below)."""
+    if not path:
+        return None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            path, "--version",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except (FileNotFoundError, PermissionError, OSError):
+        return False
+    try:
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=4)
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+            await proc.wait()
+        except ProcessLookupError:
+            pass
+        return True                        # started and kept running → it loaded fine
+    if proc.returncode is not None and proc.returncode < 0:
+        return False                       # killed by a signal → loader abort
+    blob = (out.decode("utf-8", "replace") + err.decode("utf-8", "replace")).lower()
+    return not any(m in blob for m in (
+        "dyld", "symbol not found", "error while loading shared librar",
+        "image not found", "cannot open shared object",
+    ))
+
+
+async def validate_renderers() -> "dict[str, dict]":
+    """Full exec-probe of every plain-binary renderer — the eight in
+    ``_PROBE_RENDERER_SPECS`` plus ffmpeg — for the startup health summary.
+    Returns ``{name: {"path": str, "status": "ok"|"broken"|"missing"}}``.  Each is
+    resolved via its configured ``*_path`` setting when that names an existing
+    file, else via PATH (ffmpeg's default setting is the literal ``"ffmpeg"``,
+    i.e. PATH); ``broken`` means present but fails to LOAD — the zxtune123/boost
+    and sidplayfp/libsidplayfp orphan class.  gme (in-process libgme binding) and
+    ym2wav/hvl2wav (compiled on first use) have no standalone binary to probe here
+    and are validated at use time."""
+    resolved: "dict[str, str]" = {}
+    for name, attr in list(_PROBE_RENDERER_SPECS) + [("ffmpeg", "ffmpeg_path")]:
+        configured = getattr(settings, attr, "") or ""
+        if name == "ffmpeg" and configured == "ffmpeg":
+            configured = ""                       # the literal default means "use PATH"
+        path = configured if (configured and Path(configured).is_file()) else shutil.which(name)
+        resolved[name] = path or ""
+    names = list(resolved)
+    results = await asyncio.gather(
+        *(probe_renderer_runs(resolved[n]) if resolved[n] else _none() for n in names)
+    )
+    out: "dict[str, dict]" = {}
+    for name, runs in zip(names, results):
+        path = resolved[name]
+        out[name] = {"path": path,
+                     "status": "missing" if not path else ("ok" if runs else "broken")}
+    return out
+
+
+async def _none():
+    """Awaitable that yields ``None`` (for a renderer with no resolved path)."""
+    return None
+
+
 @router.get("/renderers")
 async def check_renderers(_tok: str = Depends(_require_token)):
     """Check which format renderers are installed."""
@@ -1846,7 +1963,7 @@ async def check_renderers(_tok: str = Depends(_require_token)):
         return {"installed": bool(cxx),
                 "path": f"(builds on first use{'' if cxx else ' — NO C++ compiler found'})"}
 
-    return {
+    _status = {
         "ffmpeg": ff_check,
         "sidplayfp": _check(settings.sidplayfp_path, "sidplayfp"),
         "fluidsynth": _check(settings.fluidsynth_path, "fluidsynth"),
@@ -1867,6 +1984,33 @@ async def check_renderers(_tok: str = Depends(_require_token)):
         "ym2wav": _bundled("ym2wav"),
         "hvl2wav": _bundled("hvl2wav"),
     }
+    # ``installed`` only means the file exists.  Actually EXEC the plain-binary
+    # renderers so a present-but-broken one (dyld/loader failure — e.g. a
+    # prebuilt zxtune123 orphaned by a Homebrew boost bump) reports runs:false
+    # and shows red in the UI instead of a false ✓.  ffmpeg carries its own
+    # richer feature-probe above; gme is the in-process libgme binding and
+    # ym2wav/hvl2wav build on first use, so none of those has a standalone binary
+    # to run here.  Probed concurrently with a short timeout, so the added
+    # latency is one slow probe, not their sum.
+    _probe_keys = [
+        k for k in ("sidplayfp", "fluidsynth", "openmpt123", "uade123",
+                    "adplay", "psgplay", "sc68", "zxtune123")
+        if _status[k].get("installed") and _status[k].get("path")
+    ]
+    if _probe_keys:
+        # Defensive: probing is best-effort UI enrichment — an unexpected escape
+        # (a transport error, or CancelledError on client disconnect mid-probe)
+        # must not 500 the whole panel.  Leave ``runs`` unset on failure.
+        try:
+            _runs = await asyncio.gather(
+                *(probe_renderer_runs(_status[k]["path"]) for k in _probe_keys)
+            )
+            for _k, _r in zip(_probe_keys, _runs):
+                if _r is not None:
+                    _status[_k]["runs"] = _r
+        except Exception:
+            log.debug("renderer run-probe failed", exc_info=True)
+    return _status
 
 
 # ── Bundled ffmpeg installer ────────────────────────────────────────────────

--- a/soniqboom/api/artist.py
+++ b/soniqboom/api/artist.py
@@ -5,12 +5,37 @@
 Wikipedia (keyless) and cached to disk. Surfaced in the Track Info panel."""
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Query
 
 from soniqboom.core.artistinfo import get_artist_info
 from soniqboom.core.retro import is_retro_format
 
 router = APIRouter(tags=["artist"])
+log = logging.getLogger(__name__)
+
+
+def _persist_scene_meta(track_id: str, wb: dict) -> None:
+    """Opportunistically fill EMPTY ``composer`` / ``scene_group`` from a resolved
+    title-first scene card, so the author + crew index for search.  Best-effort;
+    never raises; never overwrites existing values.  Runs ON the event-loop thread
+    on purpose — the store's in-memory search index is mutated here and is not
+    safe to touch from a worker thread while the loop serves a concurrent read
+    (mirrors ``demozoo.apply_to_library``, which keeps its store write on-loop)."""
+    try:
+        from soniqboom.core.store import get_store
+        store = get_store()
+        t = store.get_track(track_id) or {}
+        upd: dict = {}
+        if wb.get("composer") and not (t.get("composer") or "").strip():
+            upd["composer"] = wb["composer"]
+        if wb.get("scene_group") and not (t.get("scene_group") or "").strip():
+            upd["scene_group"] = wb["scene_group"]
+        if upd:
+            store.update_track_fields(track_id, upd)
+    except Exception:                       # noqa: BLE001 — enrichment, never fail the card
+        log.debug("scene-meta persist failed for %s", track_id, exc_info=True)
 
 
 @router.get("/artist/info")
@@ -42,22 +67,53 @@ async def artist_info(
 
 @router.get("/artist/scene")
 async def artist_scene(
-    name: str = Query(..., min_length=1, max_length=200),
+    name: str | None = Query(default=None, max_length=200),
     track: str | None = Query(default=None, max_length=300),
     format: str | None = Query(default=None, max_length=80),
+    track_id: str | None = Query(default=None, max_length=256),
+    year: int | None = Query(default=None),
     retro: bool = Query(default=False),
 ):
     """Demoscene enrichment for a retro track's SCENE tab.
 
-    Resolves the composer on Demozoo (same confidence gate + shared-handle
-    disambiguation as ``/artist/info``) and returns their identity, discography,
+    Resolves the composer on Demozoo and returns their identity, discography,
     and — when this track matches one of their productions — that production's
     release details (canonical date/year, type, platform, release party,
     competition placing, links).  Only for scene music (an explicit ``retro``
     flag or a static retro ``format``); returns ``{found: False}`` otherwise so
     the panel falls back to baseline module context.
+
+    Two resolution modes: with a ``name`` (structured artist tag) it's NAME-first
+    (same confidence gate + shared-handle disambiguation as ``/artist/info``).
+    With NO name — a scene module that carries only a song title — it's
+    TITLE-first: match the SONG TITLE (``track``) to a Demozoo production, and
+    when several sceners share that title, narrow by the ``year`` or by author
+    hints derived from the module (in-module "by X" credit, the archive's artist
+    directory, the title's trailing handle).  Refuses over guessing either way.
     """
     if not (retro or is_retro_format(format)):
         return {"found": False}
     from soniqboom.core import demozoo
-    return await demozoo.scene_card(name, track_title=track)
+    if name and name.strip():
+        return await demozoo.scene_card(name.strip(), track_title=track)
+    # Title-first — no artist tag.  Pull the module's hint signals from the store.
+    if not (track and track.strip()):
+        return {"found": False}
+    _path = _insts = None
+    if track_id:
+        try:
+            from soniqboom.core.store import get_store
+            t = get_store().get_track(track_id) or {}
+            _path, _insts = t.get("path"), t.get("instruments")
+            if year is None:
+                year = t.get("year")
+        except Exception:                       # noqa: BLE001 — hints are best-effort
+            pass
+    narrow, credits = demozoo.author_hints_from_track(
+        title=track, path=_path, instruments=_insts)
+    card = await demozoo.scene_card_by_title(
+        track, year=year, author_hints=tuple(narrow), credit_hints=credits)
+    wb = card.pop("_writeback", None) if isinstance(card, dict) else None
+    if wb and track_id:                     # opportunistic (a): persist author + crew
+        _persist_scene_meta(track_id, wb)   # on the event-loop thread (see helper)
+    return card

--- a/soniqboom/api/fstree.py
+++ b/soniqboom/api/fstree.py
@@ -1485,17 +1485,33 @@ async def _remote_tracks_with_meta(path: str, recursive: bool) -> list[dict]:
     rh = path_hash(scan_root)
 
     if recursive:
-        dicts = store.filter_tracks(scan_root_hash=rh, limit=10000)
-        prefix = remote_path.rstrip("/")
-        if prefix != "/":
-            dicts = [
-                d for d in dicts
-                if d.get("path", "").startswith(f"{scan_root}:{prefix}/")
-            ]
-    else:
-        dh = path_hash(remote_path)
-        dicts = store.filter_tracks(dir_hash=dh, scan_root_hash=rh, limit=5000)
+        # Collect EVERY indexed track under the folder from the scan-root's
+        # sorted-path cache (already TrackMeta-shaped) via a bisect over the
+        # ``{scan_root}:/{rel}/`` prefix — the same O(log n + k) walk the
+        # ``_remote_children_from_store`` / ``_subtree_has_indexed_audio``
+        # helpers use.  The old ``filter_tracks(scan_root_hash, limit=10000)``
+        # + Python prefix-filter fetched only the FIRST 10 000 tracks of the
+        # whole scan root and filtered those, so a folder whose tracks fell
+        # outside that window (e.g. an artist deep in a full iTunes library >
+        # 10 000 tracks) came back EMPTY — the parent folder showed "No tracks
+        # found" while its leaf album folders, queried directly by dir_hash
+        # below, still worked.  The bisect is unbounded and scan-root-size
+        # independent, and returns tracks in stable path order.
+        from bisect import bisect_left
+        sorted_paths, sorted_dicts = _get_or_build_scan_root_sorted(store, rh)
+        rel = remote_path.strip("/")
+        prefix = f"{scan_root}:/" + (f"{rel}/" if rel else "")
+        i = bisect_left(sorted_paths, prefix)
+        n = len(sorted_paths)
+        out: list[dict] = []
+        while i < n and sorted_paths[i].startswith(prefix):
+            out.append(sorted_dicts[i])       # already model-dumped + _scanned
+            i += 1
+        return out
 
+    # Non-recursive: the tracks DIRECTLY inside this folder, by dir hash.
+    dh = path_hash(remote_path)
+    dicts = store.filter_tracks(dir_hash=dh, scan_root_hash=rh, limit=5000)
     results: list[dict] = []
     for d in dicts:
         try:

--- a/soniqboom/api/library.py
+++ b/soniqboom/api/library.py
@@ -515,3 +515,15 @@ async def list_formats(request: Request):
         cached = store.aggregate_formats(primary_only=_dedup_on(store))
         _cache_set("formats", cached)
     return _etag_response(request, "formats", cached)
+
+
+@router.get("/scene-groups")
+async def list_scene_groups(request: Request):
+    """Demoscene groups with track counts — the browse facet over the Demozoo
+    ``scene_group`` enrichment.  Empty until the Demozoo apply has run."""
+    cached = _cache_get("scene_groups")
+    if cached is None:
+        store = get_store()
+        cached = store.aggregate_scene_group(primary_only=_dedup_on(store))
+        _cache_set("scene_groups", cached)
+    return _etag_response(request, "scene_groups", cached)

--- a/soniqboom/api/search.py
+++ b/soniqboom/api/search.py
@@ -131,6 +131,7 @@ async def filter_tracks(
     album_artist: str | None = None,
     album: str | None = None,
     genre: str | None = None,
+    scene_group: str | None = None,
     format: str | None = None,
     year_min: int | None = None,
     year_max: int | None = None,
@@ -143,6 +144,19 @@ async def filter_tracks(
     matching on artist / album_artist / album.  Genre stays as TagField with
     default comma separator.
     """
+    # ``scene_group`` (the Demozoo browse facet) is NOT a full-text field, so
+    # resolve it — and any co-filters — straight against the store's maintained
+    # ``_tag_scene_group`` index rather than the FT engine.
+    if scene_group:
+        from soniqboom.core.store import get_store
+        store = get_store()
+        return store.filter_tracks(
+            artist=artist, album_artist=album_artist, album=album, genre=genre,
+            scene_group=scene_group, format_=format,
+            year_min=year_min, year_max=year_max, limit=limit, offset=offset,
+            # Honour the "hide duplicates" config so the drill-down LIST matches
+            # the deduped browse COUNT (every FT-routed facet already does this).
+            filter_duplicates=bool(store.get_config("filter_duplicates", False)))
     parts: list[str] = []
     if artist:
         parts.append(f"@artist_tag:{{{_esc_tag(artist)}}}")

--- a/soniqboom/api/stream.py
+++ b/soniqboom/api/stream.py
@@ -392,6 +392,25 @@ async def _await_renderer(
                         "like non-module data (e.g. a PC/DOS file) indexed by "
                         "mistake.",
                     )
+                # A dynamic-LOADER failure: the binary is present but can't start
+                # because a shared library was upgraded out from under it (e.g.
+                # Homebrew bumped boost under a from-source zxtune123 → dyld
+                # "Symbol not found").  An install/setup problem, not bad input —
+                # give an actionable message, not a cryptic "exited with status -6".
+                if any(m in low for m in (
+                    "dyld", "symbol not found", "error while loading shared librar",
+                    "image not found", "cannot open shared object",
+                )):
+                    log.error(
+                        "%s renderer at %s FAILS TO LOAD (exit %s): %s — a system "
+                        "library upgrade likely orphaned it; re-run install.sh",
+                        kind, cmd[0], proc.returncode, err_text.strip()[:300])
+                    raise HTTPException(
+                        501,
+                        f"The {kind} renderer is installed but can't run — a shared "
+                        f"library was upgraded out from under it. Reinstall or "
+                        f"rebuild the renderer to fix it.",
+                    )
                 if err_text.strip():
                     log.warning(
                         "%s renderer failed (exit %s): %s", kind,

--- a/soniqboom/api/tracks.py
+++ b/soniqboom/api/tracks.py
@@ -244,6 +244,65 @@ async def update_year(track_id: str, body: _YearUpdate, user=_Depends(_require_e
     get_store().update_track_fields(track_id, updates)
     return {"id": track_id, "applied": updates}
 
+
+class _MetaUpdate(_BaseModel):
+    title: str | None = None
+    artist: str | None = None
+    album: str | None = None
+    album_artist: str | None = None
+    genre: str | None = None          # comma-separated; stored as a list
+    composer: str | None = None
+    comment: str | None = None
+    year: int | None = None
+
+
+_META_TEXT_FIELDS = ("title", "artist", "album", "album_artist", "composer", "comment")
+
+
+@router.put("/{track_id}/meta")
+async def update_meta(track_id: str, body: _MetaUpdate, user=_Depends(_require_edit)):
+    """Store-only metadata edit — the metadata editor for formats that can't be
+    tag-written (modules, SID, chip, archive members, remote shares).
+
+    Only the fields the client actually sends are touched (partial update).
+    Each hand-set field is recorded in ``user_edited`` so a rescan's fresh file
+    extract doesn't revert it (see store._carry_enrichment); ``year`` rides its
+    own provenance (year_source=user + year_file preserved once), exactly like
+    PUT /{id}/year, so the two stay consistent.  No file is written, so this
+    works for any format/source.
+    """
+    from soniqboom.core.store import get_store
+    store = get_store()
+    t = store.get_track(track_id)
+    if not t:
+        raise HTTPException(404, "Track not found")
+    fields = body.model_dump(exclude_unset=True)     # only what the client sent
+    updates: dict = {}
+    edited = set(x for x in (t.get("user_edited") or []) if isinstance(x, str))
+    for k, v in fields.items():
+        if k == "year":
+            if v is not None and not (1000 <= int(v) <= 2100):
+                raise HTTPException(422, "Year must be between 1000 and 2100.")
+            updates["year"] = int(v) if v is not None else None
+            updates["year_source"] = "user"
+            if t.get("year_source") not in ("user", "demozoo") and t.get("year") is not None:
+                updates["year_file"] = t.get("year")
+            # year is tracked by year_source, not user_edited
+        elif k == "genre":
+            updates["genre"] = [g.strip() for g in (v or "").split(",") if g.strip()]
+            edited.add("genre")
+        elif k in _META_TEXT_FIELDS:
+            updates[k] = "" if v is None else str(v)
+            edited.add(k)
+    if not updates:
+        return {"id": track_id, "applied": {}}
+    if any(k != "year" for k in updates if k not in ("year_source", "year_file")):
+        updates["user_edited"] = sorted(edited)
+    store.update_track_fields(track_id, updates)
+    # Edited artist/title/album change the LRCLib match — drop cached lyrics.
+    _lyrics_cache.pop(track_id, None)
+    return {"id": track_id, "applied": updates}
+
 # ── Shared httpx client for LRCLib requests ──────────────────────────────────
 
 _lrclib_client: httpx.AsyncClient | None = None

--- a/soniqboom/config.py
+++ b/soniqboom/config.py
@@ -617,8 +617,16 @@ class Settings(BaseSettings):
 
 
 def load_prefs() -> dict:
-    if PREFS_PATH.exists():
-        return json.loads(PREFS_PATH.read_text())
+    try:
+        if PREFS_PATH.exists():
+            return json.loads(PREFS_PATH.read_text())
+    except (OSError, ValueError):
+        # Corrupt/unreadable prefs must not raise — callers (and the demozoo
+        # auto-apply toggle) fall back to defaults, and the next save_prefs
+        # overwrites the bad file, self-healing.  Mirrors load_local_conf.
+        import logging
+        logging.getLogger(__name__).warning(
+            "prefs file unreadable/corrupt; using defaults", exc_info=True)
     return {}
 
 

--- a/soniqboom/core/conversion_cache.py
+++ b/soniqboom/core/conversion_cache.py
@@ -699,13 +699,36 @@ async def get_or_render(
             502, "Cache fill failed in a concurrent render — try again",
         )
 
-    try:
-        tmp_path = await render_fn()
-        dest = await store_cached(key, format_type, tmp_path)
-        return dest, False
-    finally:
-        event.set()
-        _inflight.pop(key, None)
+    # Run the render + store in a DETACHED, shield-protected task so a client
+    # disconnect (which cancels THIS caller) doesn't abort a mostly-done render.
+    # It finishes in the background and fills the cache, so the next play — the
+    # returning listener, or a Subsonic/DLNA/cast retry — is instant instead of
+    # re-rendering from scratch (the blocking analogue of the progressive path's
+    # detach-and-finish).  The inflight Event + slot are released by the TASK, so
+    # waiters wake correctly whether or not the original caller stuck around; SID
+    # renders are bounded by ``stream._sid_blocking_sem`` so detached ones can't
+    # pile up unbounded, and other formats' renders are short.
+    async def _render_and_store() -> Path:
+        try:
+            tmp_path = await render_fn()
+            return await store_cached(key, format_type, tmp_path)
+        finally:
+            event.set()
+            _inflight.pop(key, None)
+
+    task = asyncio.ensure_future(_render_and_store())
+    _detached_renders.add(task)
+
+    def _reap(t: asyncio.Task) -> None:
+        _detached_renders.discard(t)
+        if not t.cancelled():
+            t.exception()          # retrieve so a caller-cancelled failure doesn't warn
+
+    task.add_done_callback(_reap)
+    # shield: a cancelled caller re-raises CancelledError but leaves the task
+    # running to completion (and to fill the cache).
+    dest = await asyncio.shield(task)
+    return dest, False
 
 
 # ── SID progressive playback helpers ─────────────────────────────────────────
@@ -727,6 +750,11 @@ _bg_renders: "weakref.WeakValueDictionary[str, asyncio.Task]" = (
 # entries immediately on task completion (no orphan keys) while the asyncio
 # task itself stays alive for the duration of its execution.
 _bg_render_strong: set[asyncio.Task] = set()
+
+# Strong refs to detached get_or_render tasks (see get_or_render): a client
+# disconnect cancels the caller but the shielded render task must survive to
+# finish + cache, so it needs a reference the GC won't collect mid-run.
+_detached_renders: set[asyncio.Task] = set()
 
 
 async def find_shorter_sid_entry(

--- a/soniqboom/core/demozoo.py
+++ b/soniqboom/core/demozoo.py
@@ -45,6 +45,7 @@ _TABLES = {
 # current track's title matches ONE candidate's production; otherwise it refuses.
 _PROD_AUTHOR = "public.productions_production_author_nicks"   # M2M production↔nick
 _PROD_TABLE = "public.productions_production"                 # production→title
+_PROD_SOUNDTRACK = "public.productions_soundtracklink"        # demo↔the music it uses
 
 _STOP = frozenset(
     "a an and at by de el for from in la le of on or the to with".split())
@@ -73,6 +74,16 @@ def _toks_match(track: frozenset, prod: frozenset) -> bool:
     return shared >= 2 and shared >= (min(len(track), len(prod)) + 1) // 2
 
 
+def _destylize(s: object) -> str:
+    """Undo common scene title stylizations before matching a production title:
+    "][" (and "]|[") is how modules write the Roman "II", so "Unreal ][" matches
+    Demozoo's "Unreal II".  Applied only to the loose production-title match, not
+    the confidence-critical identity resolvers."""
+    if not isinstance(s, str):
+        return ""
+    return s.replace("]|[", " ii ").replace("][", " ii ")
+
+
 def _year_toks(s: object) -> frozenset:
     """Title tokens for the YEAR gate — like ``_title_toks`` but keeps single
     DIGITS.  ``_title_toks`` drops <2-char tokens, so "Last Ninja 2" collapses
@@ -97,6 +108,44 @@ def _db_path() -> Path:
     return d / "demozoo.sqlite"
 
 
+def has_index() -> bool:
+    """Cheap check for a built local index — no sqlite open (used by the
+    post-scan auto-apply to skip work when nothing has been downloaded yet)."""
+    try:
+        return _db_path().exists()
+    except Exception:                                   # noqa: BLE001
+        return False
+
+
+def last_apply_at() -> int:
+    """Unix time of the last successful apply, or 0 — for debouncing the
+    post-scan auto-apply so back-to-back scans don't re-churn the whole library."""
+    la = _status.get("last_apply") or {}
+    return int(la.get("at") or 0)
+
+
+def auto_apply_enabled() -> bool:
+    """Whether a completed library scan re-runs the Demozoo apply automatically.
+    Default ON; the Reset button turns it OFF (so a reset holds across scans) and
+    Apply turns it back ON.  Persisted in prefs so it survives a restart."""
+    from soniqboom.config import load_prefs
+    try:
+        return bool(load_prefs().get("demozoo_auto_apply", True))
+    except Exception:                                   # noqa: BLE001
+        return True
+
+
+def set_auto_apply(enabled: bool) -> None:
+    """Persist the post-scan auto-apply preference (see ``auto_apply_enabled``)."""
+    from soniqboom.config import load_prefs, save_prefs
+    try:
+        prefs = load_prefs()
+        prefs["demozoo_auto_apply"] = bool(enabled)
+        save_prefs(prefs)
+    except Exception:                                   # noqa: BLE001
+        log.warning("could not persist demozoo_auto_apply", exc_info=True)
+
+
 def status() -> dict:
     db = _db_path()
     exists = db.exists()
@@ -115,6 +164,7 @@ def status() -> dict:
         except Exception:                                   # noqa: BLE001
             names = _status["names"]
     return {**_status, "names": names, "exists": exists,
+            "auto_apply": auto_apply_enabled(),
             "size": db.stat().st_size if exists else 0}
 
 
@@ -157,6 +207,7 @@ def _parse_dump(path: Path):
     prod_title: dict[str, str | None] = {}      # production_id → title
     prod_super: dict[str, str | None] = {}      # production_id → supertype
     prod_yr: dict[str, int] = {}                # production_id → release year
+    soundtrack_of: dict[str, list[str]] = {}    # music_prod_id → [demo_prod_id]
     cur: str | None = None
     cols: list[str] | None = None
     idx: dict[str, int] = {}
@@ -166,7 +217,8 @@ def _parse_dump(path: Path):
                 if line.startswith("COPY "):
                     m = re.match(r"COPY (public\.\w+) \(([^)]*)\) FROM stdin;", line)
                     if m and (m.group(1) in _TABLES
-                              or m.group(1) in (_PROD_AUTHOR, _PROD_TABLE)):
+                              or m.group(1) in (_PROD_AUTHOR, _PROD_TABLE,
+                                                _PROD_SOUNDTRACK)):
                         cur = m.group(1)
                         cols = [c.strip() for c in m.group(2).split(",")]
                         idx = {c: i for i, c in enumerate(cols)}
@@ -184,6 +236,13 @@ def _parse_dump(path: Path):
                 pi, ni = idx.get("production_id"), idx.get("nick_id")
                 if pi is not None and ni is not None:
                     prod_nicks.setdefault(parts[pi], []).append(parts[ni])
+            elif cur == _PROD_SOUNDTRACK:
+                # ``production_id`` = the DEMO/intro; ``soundtrack_id`` = the
+                # MUSIC it uses.  Invert to music→[demos] for the "featured in"
+                # lookup (a track knows nothing about the demos that used it).
+                di, mi = idx.get("production_id"), idx.get("soundtrack_id")
+                if di is not None and mi is not None:
+                    soundtrack_of.setdefault(parts[mi], []).append(parts[di])
             elif cur == _PROD_TABLE:
                 ii, ti, si = idx.get("id"), idx.get("title"), idx.get("supertype")
                 if ii is not None and ti is not None:
@@ -318,7 +377,26 @@ def _parse_dump(path: Path):
                 for toks in rel_prod_toks.get(rid, ()):
                     ambig.append(
                         (name, rid_int, real or name, groups, " ".join(sorted(toks))))
-    return unique, ambig, prod_years
+
+    # "Featured in" evidence: for each MUSIC production, the demos/intros that
+    # used it as their soundtrack — resolved to the demo's title + year for the
+    # SCENE tab's release block.  Keyed by the music production's Demozoo id (the
+    # same id the live discography match yields in scene_card).
+    prod_soundtrack: list[tuple[int, str, int | None]] = []   # (music_id, demo_title, demo_year)
+    for music_id, demo_ids in soundtrack_of.items():
+        try:
+            m_int = int(music_id)
+        except (TypeError, ValueError):
+            continue
+        seen: set[str] = set()
+        for demo_id in demo_ids:
+            if demo_id in seen:
+                continue
+            seen.add(demo_id)
+            title = prod_title.get(demo_id)
+            if title:
+                prod_soundtrack.append((m_int, title, prod_yr.get(demo_id)))
+    return unique, ambig, prod_years, prod_soundtrack
 
 
 def refresh_index(dump_path: Path | None = None) -> dict:
@@ -349,7 +427,7 @@ def refresh_index(dump_path: Path | None = None) -> dict:
             src = tmp
         else:
             src = dump_path
-        unique, ambig, prod_years = _parse_dump(src)
+        unique, ambig, prod_years, prod_soundtrack = _parse_dump(src)
         db = _db_path()
         con = sqlite3.connect(db)
         try:
@@ -385,13 +463,25 @@ def refresh_index(dump_path: Path | None = None) -> dict:
                 except (TypeError, ValueError):
                     continue
             con.executemany("INSERT INTO prod_year VALUES (?,?,?)", _py_rows)
+            con.execute("DROP TABLE IF EXISTS prod_soundtrack")
+            con.execute("CREATE TABLE prod_soundtrack "
+                        "(music_id INTEGER, demo_title TEXT, demo_year INTEGER)")
+            con.execute("CREATE INDEX ix_prod_soundtrack ON prod_soundtrack(music_id)")
+            _st_rows = []
+            for mid, dtitle, dyear in prod_soundtrack:
+                try:
+                    _st_rows.append((int(mid), dtitle,
+                                     int(dyear) if dyear is not None else None))
+                except (TypeError, ValueError):
+                    continue
+            con.executemany("INSERT INTO prod_soundtrack VALUES (?,?,?)", _st_rows)
             con.commit()
         finally:
             con.close()
         _status.update(built_at=int(time.time()), names=len(unique))
         log.info("Demozoo index built: %d unique names + %d shared-handle "
-                 "production rows + %d dated music productions",
-                 len(unique), len(ambig), len(prod_years))
+                 "production rows + %d dated music productions + %d soundtrack links",
+                 len(unique), len(ambig), len(prod_years), len(prod_soundtrack))
     except Exception as exc:                            # noqa: BLE001
         _status["error"] = f"refresh failed: {exc}"
         log.warning("Demozoo refresh failed: %s", exc)
@@ -507,8 +597,34 @@ def collect_updates() -> tuple[int, list[tuple[str, dict]]]:
             stamped = t.get("year_source") == "demozoo"
             a = (t.get("artist") or "").strip()
             if not a:
+                # No artist tag — TITLE-first: resolve the composer from the song
+                # title, but ONLY when the module carries an author hint (an
+                # in-module "by X" credit or a multi-word archive dir) — that both
+                # bounds the cost (the LIKE scans are skipped for the vast
+                # unresolvable majority) and keeps precision high (a hint-
+                # corroborated resolution, ``_display`` set).  Stamp the author
+                # into ``composer`` (leaving ``artist`` blank so the SCENE tab
+                # stays title-first) + the crew into ``scene_group``; both index
+                # for search.  Only fills EMPTY fields.
+                upd: dict = {}
                 if stamped:
-                    batch.append((t["id"], _revert(t)))
+                    upd.update(_revert(t))
+                if not (t.get("composer") or "").strip():
+                    narrow, credits = author_hints_from_track(
+                        title=t.get("title"), path=t.get("path"),
+                        instruments=t.get("instruments"))
+                    if credits:                              # only a music CREDIT may write
+                        tb = lookup_by_title(t.get("title") or "",
+                                             author_hints=tuple(narrow),
+                                             credit_hints=credits)
+                        if tb and tb.get("_persist"):        # credit-corroborated only
+                            matched += 1
+                            upd["composer"] = tb["_persist"]
+                            crew = " • ".join(tb.get("groups") or [])
+                            if crew and not (t.get("scene_group") or "").strip():
+                                upd["scene_group"] = crew   # fill-only
+                if upd:
+                    batch.append((t["id"], upd))
                 continue
             ttoks = _title_toks(t.get("title"))
             rid = None
@@ -644,22 +760,53 @@ def lookup_scener(name: str, track_title: str | None = None) -> dict | None:
             if len(hits) == 1:
                 rid, row = next(iter(hits.items()))
                 return _scener_card(rid, row[1], row[2])
-            if len(hits) > 1:                   # variants disagree → refuse
+            if len(hits) > 1:
+                # Variants disagree (only possible when the artist carries a
+                # parenthetical).  A parenthetical group/handle that collides
+                # with an UNRELATED scener must not veto the authoritative
+                # pre-paren name — "Mark Cooksey (Dr K)" is the person "mark
+                # cooksey"; "dr k" is a homonym of a different scener.  Prefer
+                # the paren-stripped primary when it alone resolves to one
+                # scener; otherwise the disagreement is genuine → refuse.
+                primary = _norm(re.sub(r"\([^)]*\)", "", name))
+                if len(primary) >= 2:
+                    row = con.execute(
+                        "SELECT releaser_id, real_name, groups FROM scener "
+                        "WHERE name = ?", (primary,)).fetchone()
+                    if row and row[0] is not None:
+                        return _scener_card(int(row[0]), row[1], row[2])
                 return None
-            # 2) Shared handle — pick the candidate whose production matches THIS
-            #    track's title.  No title / no match / >1 match ⇒ refuse.
-            ttoks = _title_toks(track_title)
-            if len(ttoks) < 2 or not _has_ambig_table(con):
+            # 2) Shared handle.  A name lands in ``ambig_prod`` when >1 Demozoo
+            #    releaser carries it — but only the ones who RELEASED something
+            #    appear here, so a "shared" handle often has a single real
+            #    candidate (the productionless namesakes can't be a music
+            #    track's author).  Gather the candidates:
+            if not _has_ambig_table(con):
                 return None
-            winners: dict[int, tuple] = {}
+            cands: dict[int, tuple] = {}        # rid → (real, groups)
+            prods: dict[int, list[frozenset]] = {}
             for v in variants:
                 for rid, real, groups, ptoks in con.execute(
                     "SELECT releaser_id, real_name, groups, ptoks "
                     "FROM ambig_prod WHERE name = ?", (v,),
                 ):
-                    if rid is not None and _toks_match(
-                            ttoks, frozenset((ptoks or "").split())):
-                        winners[int(rid)] = (real, groups)
+                    if rid is None:
+                        continue
+                    rid = int(rid)
+                    cands[rid] = (real, groups)
+                    prods.setdefault(rid, []).append(
+                        frozenset((ptoks or "").split()))
+            if not cands:
+                return None
+            if len(cands) == 1:                 # sole producer of that handle → them
+                rid, (real, groups) = next(iter(cands.items()))
+                return _scener_card(rid, real, groups)
+            # Genuinely >1 candidate — the track title must pick ONE production.
+            ttoks = _title_toks(track_title)
+            if len(ttoks) < 2:
+                return None
+            winners = {rid: cands[rid] for rid, plist in prods.items()
+                       if any(_toks_match(ttoks, pt) for pt in plist)}
             if len(winners) != 1:              # 0 = no evidence, >1 = still ambiguous
                 return None
             rid, (real, groups) = next(iter(winners.items()))
@@ -916,26 +1063,298 @@ async def fetch_production_detail(production_id: int) -> dict | None:
     return out
 
 
-async def scene_card(name: str, track_title: str | None = None) -> dict:
-    """Full demoscene enrichment for a retro track's SCENE tab.
+def _production_soundtracks(music_id: object, limit: int = 6) -> list[dict]:
+    """Demos/intros that used a MUSIC production as their soundtrack, newest
+    first → ``[{title, year}]``.  Offline + best-effort: empty on any error or a
+    pre-soundtrack index (no ``prod_soundtrack`` table) — never raises."""
+    try:
+        mid = int(music_id)
+    except (TypeError, ValueError):
+        return []
+    db = _db_path()
+    if not db.exists():
+        return []
+    try:
+        con = sqlite3.connect(db)
+        try:
+            if not con.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' "
+                "AND name='prod_soundtrack'"
+            ).fetchone():
+                return []
+            rows = con.execute(
+                "SELECT demo_title, demo_year FROM prod_soundtrack WHERE music_id = ?",
+                (mid,),
+            ).fetchall()
+        finally:
+            con.close()
+    except sqlite3.Error:
+        return []
+    seen: set[str] = set()
+    out: list[dict] = []
+    for title, year in sorted(rows, key=lambda r: (r[1] or 0), reverse=True):
+        t = (title or "").strip()
+        if t and t.lower() not in seen:
+            seen.add(t.lower())
+            out.append({"title": t, "year": year})
+        if len(out) >= limit:
+            break
+    return out
 
-    Resolves the composer offline (Demozoo-first identity, same confidence gate
-    as ``artist_card`` — including shared-handle disambiguation by ``track_title``)
-    then LIVE-enriches with their discography and, when the current track matches
-    exactly ONE of their productions by title, that production's release details
-    (canonical date/year → the retro year overwrite, type, platform, release
-    party, competition placing, links).  Every live call is disk-cached; any
-    failure degrades to identity-only.  Never raises.
 
-    Returns ``{found, artist, discography, release}`` (``found: False`` when the
-    composer doesn't resolve to a scener — the panel then shows only baseline
-    module context).
+# A "by X" credit in a module's sample/instrument text names the COMPOSER only
+# when it is a bare "By X" signature or is qualified by a MUSIC word ("music by
+# X", "composed by X", "tune by X").  A wrong composer write is permanent, so
+# the word before "by" is gated by POSITION (the sample list is one credit
+# fragment per slot):
+#   • same slot  → WHITELIST — only a music word or nothing; a blacklist is
+#     unwinnable there (defeated by any omitted word "gr by X", and by any
+#     punctuation that detaches the prefix "graphics: by X").
+#   • previous slot (a bare "By X" here, its role word one slot up) → a targeted
+#     ROLE blacklist; a whitelist would wrongly kill 800+ real "By <scener>"
+#     signatures that trail unrelated sample text (measured on the library).
+_MUSIC_BY_WORDS = frozenset(
+    "music musik musics muzik muzak composed compose composition composer "
+    "tune tunes song songs melody melodies score scored soundtrack theme "
+    "tracked mus msc".split())              # "tracked" = sequenced in a tracker
+_ROLE_BY_WORDS = frozenset(
+    "gfx graphics graphix graphic grafix grafik grafics gr grfx gpx graphx gph "
+    "pixels pixel logo logos font fonts design designed ripped rip ripper ripping "
+    "cracked crack code coded coding program programmed programming prog "
+    "greets greetings greetz loader art artwork picture pics image images "
+    "converted conversion convert ported swap swapped trained trainer sfx fx "
+    "sound sounds sample samples sampled voice voices vocals words lyrics text "
+    "ascii ansi vga menu docs chars charset copper wizard prowizard".split())
+# name AFTER "by": starts alnum; "/" and "|" are hard stops (clause separators,
+# so a later "music by Y" after "ripped by X / …" is still reachable); "-" is
+# kept so hyphenated handles ("4-mat") survive.
+_BY_RE = re.compile(r"\bby\b\s+([A-Za-z0-9][A-Za-z0-9 .'&-]{1,39})", re.I)
+# the last alphabetic word BEFORE a "by", skipping any trailing punctuation.
+_PRED_RE = re.compile(r"([A-Za-z]+)[^A-Za-z]*$")
+_WORD_RE = re.compile(r"[A-Za-z]+")
+
+
+def _slot_role_veto(text: str) -> bool:
+    """Does a PREVIOUS sample slot veto a bare "By X" in the next slot?  Yes when
+    the slot credits a non-music ROLE ("cracked together", "converted in 0.30
+    min", "samples & jingles") and does NOT also name a music role — the WHOLE
+    slot is scanned, not just its last word, because the role verb is often
+    non-terminal.  A slot that pairs a role with a music word ("composed &
+    sampled") is not a veto: the credit is (also) musical."""
+    toks = {w.lower() for w in _WORD_RE.findall(text or "")}
+    return bool(toks & _ROLE_BY_WORDS) and not (toks & _MUSIC_BY_WORDS)
+
+
+def _music_credits(instruments: "list | None") -> list[str]:
+    """Composer handles from a module's sample/instrument text.  The sample list
+    is one credit fragment per slot, so two positions get two gates:
+      • predecessor IN the same slot → strict WHITELIST: "music/composed/tune/…
+        by X" or a bare "By X"; every other word (known-bad OR unknown) refused,
+        so an omitted role word or a punctuation-detached prefix ("graphics: by
+        X") cannot leak a wrong composer.
+      • bare "By X" whose role word is in the PREVIOUS slot → the whole previous
+        slot is scanned for a KNOWN role word (with no co-occurring music word);
+        a whitelist is wrong here (800+ real library signatures follow unrelated
+        text, measured), but a last-word-only check missed non-terminal roles
+        ("cracked together" / "by X").  Only the IMMEDIATELY preceding slot is
+        inspected — a role word ≥2 slots up (or a source named far above a bare
+        re-statement, e.g. a converted cover) is a known, rare residual.
+    A wrong composer write is permanent, so this errs toward missing a credit.
+    Original case kept."""
+    ins_list = list(instruments or [])
+    out: list[str] = []
+    for i, ins in enumerate(ins_list[:6]):
+        s = ins if isinstance(ins, str) else ""
+        for m in _BY_RE.finditer(s):
+            pm = _PRED_RE.search(s[:m.start()])
+            if pm is not None:
+                if pm.group(1).lower() not in _MUSIC_BY_WORDS:
+                    continue                # non-music / unrecognised qualifier
+            elif i > 0:                     # bare here — scan the previous slot
+                prev = ins_list[i - 1]
+                if _slot_role_veto(prev if isinstance(prev, str) else ""):
+                    continue                # "gfx"/"ripped"/… by X across slots
+            # Trim the group / collaborator / year tail so "By Purple Motion of
+            # the Future Crew", "By Purple Motion -93" and "… '97" all →
+            # "Purple Motion", while a numeric handle ("Catch 22", "Area 51") and
+            # a hyphen handle ("4-mat") are kept — only a plausible YEAR (a
+            # space-dash tail, a 'NN apostrophe-year, or 19xx/20xx) is stripped.
+            h = re.sub(r"\s+(?:of|from|feat\.?|ft\.?|and)\b.*$"
+                       r"|\s*[/&|].*$|\s+-.*$|\s+['’]\d{2}$"
+                       r"|\s+(?:19|20)\d{2}$", "",
+                       m.group(1), flags=re.I).strip(" .-'")
+            if len(h) >= 2:
+                out.append(h)
+    return out
+
+
+def author_hints_from_track(*, title: str | None = None, path: str | None = None,
+                            instruments: "list | None" = None,
+                            ) -> "tuple[list[str], dict[str, str]]":
+    """Return ``(narrow, credits)`` for a scene module with NO artist tag.
+
+    ``credits`` is ``{normalised: original-case}`` for AUTHORSHIP handles only —
+    an in-module music "by X" credit (see ``_music_credits``).  These are the ONLY
+    hints allowed to PERSIST an author (a wrong composer write is permanent), and
+    the original case is kept for the stored value.
+
+    ``narrow`` is the normalised list used ONLY to NARROW a title search for
+    DISPLAY (never to write): the credits PLUS weak signals — the archive's parent
+    directory and the title's trailing handle, kept only when multi-word (a bare
+    single word there resolves to a random namesake)."""
+    credits: dict[str, str] = {}
+    for c in _music_credits(instruments):
+        n = _norm(c)
+        if len(n) >= 2 and n not in credits:
+            credits[n] = c
+    weak: list[str] = []
+    m = re.search(r"\s[-–—]\s*([A-Za-z0-9 .'&]{2,40})$", title or "")
+    if m:
+        weak.append(m.group(1))
+    parts = [x for x in re.split(r"[/\\]", (path or "").split("::", 1)[0]) if x]
+    if len(parts) >= 2:
+        weak.append(re.sub(r"[_\-]+", " ", parts[-2]))
+    narrow = list(credits)
+    for h in weak:                                          # dir/suffix — multi-word only
+        n = _norm(h)
+        if len(n.split()) >= 2 and n not in credits and n not in narrow:
+            narrow.append(n)
+    return narrow, credits
+
+
+def _title_seed_ok(toks: frozenset) -> bool:
+    """A token set distinctive enough to search on: ≥2 tokens, or one ≥5 chars."""
+    return len(toks) >= 2 or any(len(t) >= 5 for t in toks)
+
+
+def lookup_by_title(title: str, *, year: int | None = None,
+                    author_hints: tuple = (),
+                    credit_hints: "dict | None" = None) -> dict | None:
+    """Title-FIRST offline Demozoo identity: the scener who released a production
+    whose title matches THIS track's.  A wrong attribution is worse than none, so
+    the confidence gate is strict:
+      • the title needs a distinctive seed (≥2 tokens, or one ≥5 chars);
+      • a candidate production's title must be a token-SUBSET of the track title
+        and itself distinctive;
+      • a UNIQUE candidate resolves ONLY when its production title is MULTI-word
+        (a bare single common word — "Access", "Agenda" — is coincidence, not
+        authorship) OR an author hint agrees; a SHARED title resolves ONLY when
+        the hints point to exactly one candidate; credited-author evidence that
+        points at a DIFFERENT scener refuses.
+    Refuses (``None``) otherwise.  Reads the local sqlite only; never raises.
+    Returns ``{releaser_id, real_name, groups[], url, _display}`` or ``None``.
+    ``year`` is accepted for API stability but intentionally NOT used to break
+    ties — scene rip tags carry the RIP year, not the composition year, so it
+    would select a namesake."""
+    ttoks = _title_toks(title)
+    if not _title_seed_ok(ttoks):
+        return None
+    # Search EVERY distinctive token (not just the longest) so a ripper's extra
+    # suffix ("Access [Longmix]") can't hide the real title token.  Bounded.
+    seeds = sorted((t for t in ttoks if len(t) >= 5), key=len, reverse=True)[:4]
+    if not seeds:
+        return None
+    db = _db_path()
+    if not db.exists():
+        return None
+    try:
+        con = sqlite3.connect(db)
+        try:
+            if not _has_scener_table(con) or not _has_ambig_table(con):
+                return None
+            cand: dict[int, dict] = {}
+
+            def _consider(rid: object, ptoks: object,
+                          real: object = None, groups: object = None) -> None:
+                pt = frozenset((ptoks or "").split())
+                if rid is None or not pt or not (pt <= ttoks) or not _title_seed_ok(pt):
+                    return
+                d = cand.setdefault(int(rid), {})
+                if len(pt) >= 2:
+                    d["multi"] = True                       # multi-word title = corroborated
+                if real is not None:
+                    d["real_name"], d["groups"] = real, groups
+
+            for seed in seeds:
+                like = f"%{seed}%"
+                for _n, rid, real, groups, ptoks in con.execute(
+                        "SELECT name, releaser_id, real_name, groups, ptoks "
+                        "FROM ambig_prod WHERE ptoks LIKE ?", (like,)):
+                    _consider(rid, ptoks, real, groups)
+                for rid, ptoks, _yr in con.execute(
+                        "SELECT releaser_id, ptoks, year FROM prod_year WHERE ptoks LIKE ?", (like,)):
+                    _consider(rid, ptoks)
+            if not cand:
+                return None
+            for rid, d in cand.items():                     # fill any missing name
+                if "real_name" not in d:
+                    r = (con.execute("SELECT real_name, groups FROM scener "
+                                     "WHERE releaser_id = ? LIMIT 1", (rid,)).fetchone()
+                         or con.execute("SELECT real_name, groups FROM ambig_prod "
+                                        "WHERE releaser_id = ? LIMIT 1", (rid,)).fetchone())
+                    if r:
+                        d["real_name"], d["groups"] = r[0], r[1]
+            # _H = every releaser the author hints point to; inter = candidates one
+            # points to.
+            _H: set[int] = set()
+            inter: dict[int, str] = {}
+            for h in author_hints:
+                for v in _name_variants(h):
+                    rr = con.execute("SELECT releaser_id FROM scener WHERE name = ?", (v,)).fetchone()
+                    if rr and rr[0] is not None:
+                        _H.add(int(rr[0]))
+                        if int(rr[0]) in cand:
+                            inter.setdefault(int(rr[0]), h)
+                    for (arid,) in con.execute("SELECT releaser_id FROM ambig_prod WHERE name = ?", (v,)):
+                        if arid is not None:
+                            _H.add(int(arid))
+                            if int(arid) in cand:
+                                inter.setdefault(int(arid), h)
+            # A MULTI-word production title (≥2 shared tokens) is distinctive
+            # enough to resolve on its own; single-token subset matches ("Motion"
+            # for a "Global Motion" track) are pollution and never resolve alone.
+            strong = [rid for rid, d in cand.items() if d.get("multi")]
+            winner: int | None = None
+            disp: str | None = None
+            if len(inter) == 1:                             # title + credited author AGREE
+                winner = next(iter(inter))
+                disp = inter[winner]
+            elif len(strong) == 1:                          # exactly ONE multi-word match
+                only = strong[0]
+                if _H and only not in _H:                   # credit points elsewhere → refuse
+                    return None
+                winner = only
+            if winner is None:                              # bare single word (needs a hint)
+                return None                                 # or a shared title → refuse
+            d = cand[winner]
+            card = _scener_card(winner, d.get("real_name"), d.get("groups"))
+            if disp:
+                card["_display"] = disp.title()
+                # PERSIST-eligible ONLY when the corroborating hint is a music
+                # CREDIT (not a weak dir/suffix, not the no-hint strong path) —
+                # a wrong composer write is permanent.  Original case preserved.
+                cred = (credit_hints or {}).get(disp)
+                if cred:
+                    card["_persist"] = cred
+            return card
+        finally:
+            con.close()
+    except sqlite3.Error:
+        return None
+
+
+async def _scene_card_from_base(base: dict, name: str,
+                                track_title: str | None) -> dict:
+    """Shared LIVE enrichment for an ALREADY-resolved Demozoo identity — the
+    scener's discography plus, when the current track matches exactly ONE of
+    their productions by title, that production's release details (year overwrite,
+    type, platform, party, placing, links).  Every live call is disk-cached; any
+    failure degrades to identity-only.  Never raises.  ``base`` is the offline
+    identity (``{releaser_id, real_name, groups, url}``); ``name`` is the display
+    handle.  Returns ``{found, artist, discography, release}``.
     """
     import asyncio
     try:
-        base = lookup_scener(name, track_title)
-        if base is None:
-            return {"found": False}
         rid = base["releaser_id"]
         details, prods = await asyncio.gather(
             fetch_scener_details(rid),
@@ -960,8 +1379,8 @@ async def scene_card(name: str, track_title: str | None = None) -> dict:
         # Release block — the ONE production whose title matches this track
         # (refuse >1: two matches ⇒ ambiguous, no year overwrite).
         release = None
-        ttoks = _title_toks(track_title)
-        if len(ttoks) >= 2 and prods:
+        ttoks = _title_toks(_destylize(track_title))     # "][" → "ii" so a module's
+        if len(ttoks) >= 2 and prods:                    # "Unreal ][" matches "Unreal II"
             winners = [p for p in prods
                        if _toks_match(ttoks, _title_toks(p.get("title")))]
             if len(winners) == 1:
@@ -984,6 +1403,11 @@ async def scene_card(name: str, track_title: str | None = None) -> dict:
                         "platforms": w.get("platforms") or [], "parties": [],
                         "placings": [], "links": [], "url": w.get("url") or "",
                     }
+                # "Featured in": demos/intros that used this track as their
+                # soundtrack — the reverse link the live API doesn't expose,
+                # read from the offline index (empty on a pre-soundtrack index).
+                if release is not None and w.get("id"):
+                    release["featured_in"] = _production_soundtracks(w.get("id"))
         # Discography — newest-first music, minus the current release (shown in
         # its own block), capped for the panel.
         rel_id = release.get("id") if release else None
@@ -993,8 +1417,56 @@ async def scene_card(name: str, track_title: str | None = None) -> dict:
         return {"found": True, "artist": artist,
                 "discography": disco, "release": release}
     except Exception:                       # noqa: BLE001 — never break the panel
-        log.debug("Demozoo scene_card failed for %r", name, exc_info=True)
+        log.debug("Demozoo scene-card enrichment failed for %r", name, exc_info=True)
         return {"found": False}
+
+
+async def scene_card(name: str, track_title: str | None = None) -> dict:
+    """Full demoscene enrichment for a retro track's SCENE tab, resolving the
+    composer NAME-first (Demozoo-first identity, same confidence gate as
+    ``artist_card`` — including shared-handle disambiguation by ``track_title``).
+    Returns ``{found, artist, discography, release}`` (``found: False`` when the
+    composer doesn't resolve to a scener — the panel then shows baseline context).
+    """
+    import asyncio
+    try:                                    # sqlite off the event loop; degrade on error
+        base = await asyncio.to_thread(lookup_scener, name, track_title)
+    except Exception:                       # noqa: BLE001
+        base = None
+    if base is None:
+        return {"found": False}
+    return await _scene_card_from_base(base, name, track_title)
+
+
+async def scene_card_by_title(track_title: str | None, *, year: int | None = None,
+                              author_hints: tuple = (),
+                              credit_hints: "dict | None" = None) -> dict:
+    """Title-FIRST demoscene enrichment for a retro track with NO artist tag:
+    resolve the composer from the SONG TITLE, narrowed by author hints (in-module
+    credit / archive dir / title handle) or the release year when several sceners
+    share the title.  Refuses over guessing (see ``lookup_by_title``).  Same
+    ``{found, artist, discography, release}`` shape as ``scene_card``.
+    """
+    import asyncio
+    try:                                    # LIKE scans + sqlite off the event loop
+        base = await asyncio.to_thread(
+            lookup_by_title, track_title or "", year=year,
+            author_hints=tuple(author_hints), credit_hints=credit_hints)
+    except Exception:                       # noqa: BLE001
+        base = None
+    if base is None:
+        return {"found": False}
+    # The card's ``name`` is the scene HANDLE (``a.name`` → the “handle” sub-line);
+    # prefer the resolved handle (``_display``) over the real name so a title-first
+    # card labels it like a name-first one ("Purple Motion", not "Jonne Valtonen").
+    disp = base.get("_display") or base.get("real_name") or (track_title or "")
+    card = await _scene_card_from_base(base, disp, track_title)
+    # Persist author+crew ONLY when a music CREDIT corroborated (``_persist``) —
+    # never on a bare directory/title hint.  The frontend ignores ``_writeback``.
+    if card.get("found") and base.get("_persist"):
+        card["_writeback"] = {"composer": base["_persist"],
+                              "scene_group": " • ".join(base.get("groups") or [])}
+    return card
 
 
 async def artist_card(name: str, track_title: str | None = None) -> dict | None:
@@ -1064,6 +1536,87 @@ async def apply_to_library() -> dict:
             "matched": matched, "updated": updated, "at": int(time.time()),
         }
         return {**status(), "matched": matched, "updated": updated}
+    except Exception as exc:                            # noqa: BLE001
+        _status["error"] = str(exc)
+        return {**status(), "error": str(exc)}
+    finally:
+        _status["applying"] = False
+
+
+def reset_enrichment() -> tuple[int, list[tuple[str, dict]]]:
+    """Build the batch that WITHDRAWS the Demozoo scene enrichment — the exact
+    inverse of ``collect_updates``.  (Scoped to the Demozoo layer: the separate
+    Modland artist/``scene_path`` fill is NOT touched.)
+
+    A field is cleared only when it can ONLY have come from an apply pass, and
+    a user's own hand-edit (recorded in ``user_edited``) is always preserved:
+
+      * ``year`` stamped ``year_source == "demozoo"`` → reverted to the
+        preserved ``year_file`` (a USER year, ``year_source == "user"``, is left
+        untouched);
+      * ``scene_group`` → cleared — it is a SoniqBoom-only field, never read
+        from a file tag, so any value is enrichment;
+      * ``composer`` on a NO-ARTIST retro module → cleared — module formats
+        (ProTracker, ScreamTracker, …) carry no composer tag, so such a value
+        is always the title-first enrichment.  (A composer on an artist-tagged
+        or non-retro track may be a real file/user tag and is left alone.)
+
+    Reads the store snapshot only; the caller writes the batch on the loop
+    thread (see ``reset_to_file_state``).  Idempotent — a clean library yields
+    an empty batch."""
+    from soniqboom.core.retro import is_retro_format
+    from soniqboom.core.store import get_store
+    store = get_store()
+    batch: list[tuple[str, dict]] = []
+    for t in store.all_tracks():
+        ue = t.get("user_edited") or []
+        upd: dict = {}
+        if t.get("year_source") == "demozoo":
+            upd.update(year=t.get("year_file"), year_source=None, year_file=None)
+        if (t.get("scene_group") or "").strip() and "scene_group" not in ue:
+            upd["scene_group"] = None
+        if ((t.get("composer") or "").strip()
+                and not (t.get("artist") or "").strip()
+                and is_retro_format(t.get("format"))
+                and "composer" not in ue):
+            upd["composer"] = None
+        if upd:
+            batch.append((t["id"], upd))
+    return len(batch), batch
+
+
+async def reset_to_file_state() -> dict:
+    """Async apply of ``reset_enrichment`` — collect off-loop, store WRITE on the
+    loop thread (mirrors ``apply_to_library``).  Shares the ``applying`` lock so
+    a reset and an apply can't run at once.
+
+    A Reset must LAND even if a post-scan auto-apply is mid-write, so it waits
+    (bounded) for the shared lock to clear rather than silently no-op.  The
+    caller sets the toggle OFF first, so no NEW auto-apply can start and the
+    coalescing runner breaks on the same flag — this only waits out an apply
+    that was already in flight, then supersedes it."""
+    import asyncio
+    from soniqboom.core.store import get_store
+    for _ in range(600):                                # ~60 s ceiling
+        if not _status["applying"]:
+            break                                       # no await before the
+        await asyncio.sleep(0.1)                         # claim below → atomic
+    if _status["applying"]:
+        return {**status(), "error": "apply already running"}
+    _status.update(applying=True, error=None)
+    try:
+        loop = asyncio.get_running_loop()
+        count, batch = await loop.run_in_executor(None, reset_enrichment)
+        cleared = 0
+        if batch:
+            store = get_store()
+            store.enter_batch_mode()
+            try:
+                cleared = store.update_track_fields_batch(batch)
+            finally:
+                store.exit_batch_mode()
+        _status["last_reset"] = {"cleared": cleared, "at": int(time.time())}
+        return {**status(), "cleared": cleared}
     except Exception as exc:                            # noqa: BLE001
         _status["error"] = str(exc)
         return {**status(), "error": str(exc)}

--- a/soniqboom/core/scanner.py
+++ b/soniqboom/core/scanner.py
@@ -1897,6 +1897,87 @@ _current_remote_dirs: set[str] = set()   # active remote scan roots
 _prog_batch_entered: bool = False
 
 
+# Post-scan Demozoo auto-apply — a single COALESCING runner so no scan's
+# enrichment delta is ever dropped.  Every drain sets a ``pending`` flag; the
+# runner loops while pending is set, so a scan that drains WHILE a prior apply
+# is running (or right after one) still gets folded in on the next pass instead
+# of being stranded until some unrelated future scan (QA round-1 MAJOR).  Strong
+# refs keep the task alive; a settle sleep coalesces bursts so a folder-watch
+# storm can't re-churn the whole library back-to-back on a small host.
+_scene_autoapply_tasks: set = set()
+_scene_autoapply_pending = False
+_scene_autoapply_running = False
+_SCENE_AUTOAPPLY_SETTLE_S = 10
+
+
+def _spawn_scene_autoapply() -> None:
+    """Mark the library dirty for Demozoo scene enrichment (composer groups +
+    canonical release years) and ensure the coalescing runner is going, so the
+    manual Admin → Demozoo → Apply step is no longer required after a scan.
+
+    A no-op when no index has been downloaded yet.  Idempotent (a re-apply
+    updates only what changed) and provenance survives rescans, so it never
+    fights a user's manual edit."""
+    from soniqboom.core import demozoo
+    if not demozoo.has_index():
+        return
+    if not demozoo.auto_apply_enabled():
+        return                                  # user turned post-scan re-apply
+                                                # OFF (e.g. after a Reset) — a
+                                                # scan must not silently re-enrich
+    global _scene_autoapply_pending
+    _scene_autoapply_pending = True
+    _ensure_scene_autoapply_runner()
+
+
+def _ensure_scene_autoapply_runner() -> None:
+    global _scene_autoapply_running
+    if _scene_autoapply_running:
+        return                                  # a runner is already draining `pending`
+    _scene_autoapply_running = True
+
+    async def _run() -> None:
+        from soniqboom.core import demozoo
+        global _scene_autoapply_pending, _scene_autoapply_running
+        lock_retries = 0
+        try:
+            while _scene_autoapply_pending:
+                _scene_autoapply_pending = False
+                if not demozoo.auto_apply_enabled():
+                    break                       # toggled OFF (e.g. a Reset)
+                                                # mid-coalesce — must NOT re-enrich
+                                                # a just-reset library
+                try:
+                    res = await demozoo.apply_to_library()
+                    if res.get("error") == "apply already running":
+                        # A manual Admin apply holds the lock — retry our delta
+                        # once it clears (bounded, so a WEDGED manual apply can't
+                        # spin this forever; a later scan re-triggers regardless).
+                        lock_retries += 1
+                        if lock_retries <= 5:
+                            _scene_autoapply_pending = True
+                    else:
+                        lock_retries = 0
+                        updated = res.get("updated") or 0
+                        if updated:
+                            log.info("Post-scan Demozoo auto-apply: %d track(s) "
+                                     "enriched", updated)
+                except Exception:               # noqa: BLE001 — best-effort
+                    log.debug("Post-scan Demozoo auto-apply failed", exc_info=True)
+                if _scene_autoapply_pending:
+                    # Coalesce a burst of drains (folder-watch) into fewer applies.
+                    await asyncio.sleep(_SCENE_AUTOAPPLY_SETTLE_S)
+        finally:
+            _scene_autoapply_running = False
+
+    try:
+        t = asyncio.create_task(_run(), name="demozoo-autoapply")
+        _scene_autoapply_tasks.add(t)
+        t.add_done_callback(_scene_autoapply_tasks.discard)
+    except RuntimeError:
+        _scene_autoapply_running = False        # no running loop (shouldn't happen here)
+
+
 async def _drain_scan_queue() -> None:
     """Run scans sequentially until the queue is empty."""
     global _scan_task, _current_scan_dirs, _scan_count, _progress, _prog_batch_entered
@@ -1936,6 +2017,9 @@ async def _drain_scan_queue() -> None:
             except Exception:
                 log.exception("Failed to heal batch state after scan crash")
         _current_scan_dirs = frozenset()
+    # Whole queue drained (all local + remote scans done) — fold the results
+    # into the Demozoo scene enrichment in the background.
+    _spawn_scene_autoapply()
     _scan_task = None
 
 

--- a/soniqboom/core/store.py
+++ b/soniqboom/core/store.py
@@ -52,7 +52,8 @@ def _tokenize_text(text: str) -> list[str]:
 def _tokenize_track(track: dict) -> set[str]:
     """Extract all searchable tokens from a track dict."""
     tokens: set[str] = set()
-    for field in ("title", "artist", "album_artist", "album", "composer"):
+    for field in ("title", "artist", "album_artist", "album", "composer",
+                  "scene_group"):
         tokens.update(_tokenize_text(track.get(field, "")))
     return tokens
 
@@ -156,6 +157,18 @@ def _carry_enrichment(old: dict, new: dict) -> None:
         deliberate choice, carried regardless; a DEMOZOO year is composer-
         derived, so carried only while ``artist`` is unchanged (a changed
         composer drops it, and the next apply re-evaluates)."""
+    # Store-only hand edits (non-taggable formats) are restored FIRST, so the
+    # identity comparisons below see the user's corrected artist rather than the
+    # file's stale one — otherwise editing the Artist would compute same_artist
+    # against the file value and wrongly DROP this track's scene_group and
+    # demozoo year on the next rescan.  ('year' rides its own provenance below,
+    # so it's excluded here to avoid a double-write.)
+    edited = old.get("user_edited")
+    if isinstance(edited, list) and edited:
+        for f in edited:
+            if f != "year" and f in old:
+                new[f] = old[f]
+        new["user_edited"] = list(edited)
     same_artist = old.get("artist") == new.get("artist")
     same_md5 = old.get("file_md5") == new.get("file_md5")
     if old.get("scene_group") and not new.get("scene_group") and same_artist:
@@ -1152,6 +1165,7 @@ class TrackStore:
         album_artist: str | None = None,
         album: str | None = None,
         genre: str | None = None,
+        scene_group: str | None = None,
         format_: str | None = None,
         year_min: int | None = None,
         year_max: int | None = None,
@@ -1183,6 +1197,8 @@ class TrackStore:
             sets.append(self._tag_album.get(album.lower(), set()))
         if genre:
             sets.append(self._tag_genre.get(genre.lower(), set()))
+        if scene_group:
+            sets.append(self._tag_scene_group.get(scene_group.lower(), set()))
         if format_:
             sets.append(self._tag_format.get(format_.lower(), set()))
         if dir_hash:
@@ -1657,6 +1673,36 @@ class TrackStore:
                         break
             results.append({"genre": name, "count": count})
         results.sort(key=lambda x: x["genre"].lower())
+        return self._agg_cache_set(cache_key, results)
+
+    def aggregate_scene_group(self, primary_only: bool = False) -> list[dict]:
+        """Demoscene groups with track counts — a browse facet over the Demozoo
+        ``scene_group`` enrichment (a track credited to "Fairlight • Maniacs of
+        Noise" counts under both).  Mirrors ``aggregate_genres``: ``primary_only``
+        excludes hidden duplicates (web library opts in, Subsonic keeps raw),
+        cached under a distinct ``:primary`` key."""
+        hide_dups = primary_only
+        cache_key = "scene_group:primary" if hide_dups else "scene_group"
+        cached = self._agg_cache_get(cache_key)
+        if cached is not None:
+            return cached
+        results: list[dict] = []
+        for key, tids in self._tag_scene_group.items():
+            if not tids:
+                continue
+            count = self._count_primaries(tids) if hide_dups else len(tids)
+            if count == 0:
+                continue
+            # Proper-cased display name from one member's scene_group string.
+            name = key
+            t = self._tracks.get(next(iter(tids)))
+            if t:
+                for g in (t.get("scene_group") or "").split(_SCENE_GROUP_SEP):
+                    if g.strip().lower() == key:
+                        name = g.strip()
+                        break
+            results.append({"scene_group": name, "count": count})
+        results.sort(key=lambda x: x["scene_group"].lower())
         return self._agg_cache_set(cache_key, results)
 
     def aggregate_formats(self, primary_only: bool = False) -> list[dict]:

--- a/soniqboom/frontend/css/app.css
+++ b/soniqboom/frontend/css/app.css
@@ -1234,7 +1234,7 @@ body::before {
 .col-track        { width: 54px; text-align: center; font-variant-numeric: tabular-nums; }
 .col-year         { width: 48px; }
 .col-dur          { width: 60px; text-align: right; }
-.col-format       { width: 70px; text-align: center; color: var(--text2); font-size: 11px; }
+.col-format       { width: 96px; text-align: left; color: var(--text2); font-size: 11px; }
 .col-location     { max-width: 280px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 11px; color: var(--text2); }
 
 #track-table tbody tr {
@@ -6035,6 +6035,32 @@ th.col-rating { font-size: 14px; color: var(--accent); cursor: default; }
   white-space: nowrap;
   text-transform: uppercase;
 }
+
+/* Surround-sound marker — a compact channel-layout pill (5.1 / 7.1 / 4.0) shown
+   next to the format badge in the list and next to the format name in the info
+   panel.  Rendered ONLY for real multichannel PCM audio; module/chip "channels"
+   are synth voices, not speakers, so they never get it (see surroundLabel).  The
+   text ("5.1") carries the meaning on its own.  Sits inline so it never changes
+   a virtual-scroll row's height. */
+.surround-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 0 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  line-height: 1.5;
+  vertical-align: middle;
+  white-space: nowrap;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 13%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 34%, transparent);
+  cursor: help;
+}
+/* Explicit: the display:inline-block above would otherwise beat the UA [hidden]
+   rule and leave an empty pill on every mono/stereo row. */
+.surround-badge[hidden] { display: none; }
 
 /* Track-health badge — a known playback defect flagged at scan time.  A
    leading glyph + the text label carry the meaning, so it is never conveyed

--- a/soniqboom/frontend/index.html
+++ b/soniqboom/frontend/index.html
@@ -56,7 +56,7 @@
       } catch (_) { /* private mode — fall back to default dark */ }
     })();
   </script>
-  <link rel="stylesheet" href="/assets/css/app.css?v=91">
+  <link rel="stylesheet" href="/assets/css/app.css?v=93">
 
   <!-- Critical-path JS modulepreload.  Tells the browser to fetch + parse
        these alongside the HTML/CSS so they're already in cache by the
@@ -108,7 +108,8 @@
                placeholder="Search… try  artist:Ghost  year:&gt;2020  format:FLAC"
                title='Field search: artist: album: album_artist: genre: format: year:>2020 (or <2020, or 2010-2020).  Quote values with spaces.'
                aria-label="Search library — supports artist:, album:, year:, format: filters"
-               autocomplete="off">
+               autocomplete="off"
+               readonly>
         <button id="search-clear" type="button" class="search-clear" hidden
                 aria-label="Clear search">&times;</button>
       </div>
@@ -150,6 +151,8 @@
             <li data-view="albums"       tabindex="0" role="button">Albums</li>
             <li data-view="genres"       tabindex="0" role="button">Genres</li>
             <li data-view="years"        tabindex="0" role="button">Years</li>
+            <li data-view="scene_groups" tabindex="0" role="button" hidden
+                title="Browse by demoscene group (from Demozoo enrichment)">Scene groups</li>
             <li data-view="galaxy"       tabindex="0" role="button" title="Explore your library as a galaxy of format clusters — click one to filter to that format">Galaxy</li>
           </ul>
           <div id="browse-filter-wrap" hidden>
@@ -1524,7 +1527,14 @@
             <div class="admin-io-row">
               <button id="md-demozoo-refresh" class="btn-secondary">Download / refresh index (~192&nbsp;MB)</button>
               <button id="md-demozoo-apply">Apply to library</button>
+              <button id="md-demozoo-reset" class="btn-secondary"
+                      title="Remove all Demozoo enrichment (release years, scene groups, auto-filled composers). Your own tag edits are kept.">Reset enrichment</button>
             </div>
+            <label class="admin-hint" style="display:flex;align-items:center;gap:8px;margin-top:10px;cursor:pointer">
+              <input type="checkbox" id="md-demozoo-autoapply">
+              <span>Re-apply automatically after each library scan
+                <span style="opacity:.7">(off keeps a reset in place until you re-apply)</span></span>
+            </label>
             <div id="md-demozoo-msg" class="admin-msg" style="display:none"></div>
           </div>
         </div>
@@ -1782,7 +1792,7 @@
           </div>
           <!-- Quick stats under artwork -->
           <div class="ti-stats">
-            <div class="ti-stat-row"><span id="ti-format">—</span></div>
+            <div class="ti-stat-row"><span id="ti-format">—</span><span id="ti-surround" class="surround-badge" hidden></span></div>
             <div class="ti-stat-row"><span id="ti-bit-depth">—</span> / <span id="ti-sample-rate">—</span></div>
             <div class="ti-stat-row"><span id="ti-channels">—</span> · <span id="ti-bitrate">—</span></div>
             <div class="ti-stat-row ti-stat-size"><span id="ti-file-size">—</span></div>
@@ -2237,7 +2247,7 @@
        destination produces silence (the analyser still receives data,
        so visualizers keep twitching — but no sound hits the speakers). -->
   <audio id="audio-el" preload="none" crossorigin="anonymous"></audio>
-  <script type="module" src="/assets/js/app.js?v=140"></script>
+  <script type="module" src="/assets/js/app.js?v=166"></script>
   <!-- Cast picker is intentionally a plain script (not a module) — it
        wires itself on DOMContentLoaded and exposes ``SoniqBoomCastPicker``
        on window for tests + the dev console.  Loading it as a sibling

--- a/soniqboom/frontend/js/admin.js
+++ b/soniqboom/frontend/js/admin.js
@@ -1506,12 +1506,24 @@ async function loadRendererStatus() {
       const iconEl = document.getElementById(`renderer-icon-${n}`);
       if (!iconEl) return;
       if (info && info.installed) {
+        // File exists but the binary won't actually RUN \u2014 a system library it
+        // links was upgraded out from under it (e.g. Homebrew bumped boost under
+        // a prebuilt zxtune123 \u2192 dyld symbol-not-found abort).  Distinct from
+        // "missing": the path is present, so the fix is reinstall/replace, not
+        // install.  This is the case the old file-exists check false-greened.
+        if (info.runs === false) {
+          iconEl.textContent = '!';
+          iconEl.className = 'renderer-icon renderer-warn';
+          iconEl.title =
+            `Found at ${info.path || '(configured path)'} but it fails to run \u2014 a `
+            + 'system library it depends on was likely upgraded. Reinstall or '
+            + 'replace this renderer (see the server log for the exact error).';
         // ffmpeg has a deeper feature audit \u2014 even when installed it can
         // be missing libmp3lame / libvorbis / DSD demuxers (Homebrew's
         // default bottle is a classic culprit).  Surface "warning" tier
         // so the user knows playback will fail for some formats even
         // though the binary itself exists.
-        if (n === 'ffmpeg' && info.fully_capable === false) {
+        } else if (n === 'ffmpeg' && info.fully_capable === false) {
           iconEl.textContent = '!';
           iconEl.className = 'renderer-icon renderer-warn';
           iconEl.title =
@@ -3473,7 +3485,22 @@ function _renderDemozooStatus(s) {
   }
   if (s.error) txt += ` · ${s.error}`;
   line.textContent = txt;
+  const cb = document.getElementById('md-demozoo-autoapply');
+  if (cb && typeof s.auto_apply === 'boolean') cb.checked = s.auto_apply;
 }
+
+document.getElementById('md-demozoo-autoapply')?.addEventListener('change', async (e) => {
+  const cb = e.currentTarget; const enabled = cb.checked; cb.disabled = true;
+  try {
+    const res = await api('/admin/demozoo/auto-apply',
+                          { method: 'POST', body: JSON.stringify({ enabled }) });
+    const s = await res.json().catch(() => null);
+    if (s && !s.error) _renderDemozooStatus(s);
+    else { cb.checked = !enabled; showMsg('md-demozoo-msg', (s && s.error) || `Failed: ${res.status}`, 'err'); }
+  } catch (err) {
+    cb.checked = !enabled; showMsg('md-demozoo-msg', `Failed: ${err.message}`, 'err');
+  } finally { cb.disabled = false; }
+});
 
 async function loadDemozooStatus() {
   try {
@@ -3513,6 +3540,31 @@ document.getElementById('md-demozoo-apply')?.addEventListener('click', async (e)
     }
   } catch (err) {
     showMsg('md-demozoo-msg', `Apply failed: ${err.message}`, 'err');
+  } finally { btn.disabled = false; }
+});
+
+document.getElementById('md-demozoo-reset')?.addEventListener('click', async (e) => {
+  if (!confirm(
+        'Remove ALL Demozoo enrichment from your library?\n\n'
+        + '• Release years filled from Demozoo (reverted to the file’s own)\n'
+        + '• Scene groups\n'
+        + '• Auto-filled composers on scene modules\n\n'
+        + 'Your own tag edits are kept. This also turns OFF auto-apply after '
+        + 'scans, so it stays reset until you click Apply (or re-enable the toggle).')) return;
+  const btn = e.currentTarget; btn.disabled = true;
+  try {
+    const res = await api('/admin/demozoo/reset', { method: 'POST' });
+    const s = await res.json().catch(() => null);
+    _renderDemozooStatus(s);
+    if (s && !s.error) {
+      showMsg('md-demozoo-msg',
+              `Reset: ${Number(s.cleared || 0).toLocaleString()} tracks restored to file metadata. `
+              + `Auto-apply after scans turned off.`, 'ok');
+    } else {
+      showMsg('md-demozoo-msg', (s && s.error) || `Failed: ${res.status}`, 'err');
+    }
+  } catch (err) {
+    showMsg('md-demozoo-msg', `Reset failed: ${err.message}`, 'err');
   } finally { btn.disabled = false; }
 });
 

--- a/soniqboom/frontend/js/app.js
+++ b/soniqboom/frontend/js/app.js
@@ -2125,6 +2125,7 @@ const views = {
   albums:        () => Library.showAlbums(),
   genres:        () => Library.showGenres(),
   years:         () => Library.showYears(),
+  scene_groups:  () => Library.showSceneGroups(),
   galaxy:        () => Library.showGalaxy(),
 };
 
@@ -2160,7 +2161,20 @@ function _bindNav(rootSel, viewMap) {
       );
       li.setAttribute('aria-current', 'page');
       const view = li.dataset.view;
-      if (viewMap[view]) viewMap[view]();
+      const _viewP = viewMap[view] ? viewMap[view]() : null;
+      // During a boot view-restore, fall back to All Tracks if the restored
+      // view's async render rejects (e.g. its /api fetch fails) — the default
+      // boot showAll() was skipped, so without this the pane would be left on the
+      // skeleton shimmer.  No-op for normal clicks (fire-and-forget as before).
+      if (_restoringBootView && _viewP && typeof _viewP.catch === 'function') {
+        _viewP.catch(() => {
+          // Fall back to All Tracks THROUGH its nav item (not a bare
+          // Library.showAll()) so the sidebar highlight, aria-current, and
+          // sb_last_view all move to All Tracks too — otherwise they'd stay
+          // pointing at the view whose fetch just failed.
+          try { document.querySelector('#nav-library li[data-view="all"]')?.click(); } catch (_) {}
+        });
+      }
       // Remember the last-active view across reloads so power-users land
       // back where they were (UX/UI #1 #17).
       try {
@@ -2184,25 +2198,71 @@ function _bindNav(rootSel, viewMap) {
   });
 }
 
+let _restoringBootView = false;   // true only while the boot view-restore click runs
 _bindNav('#nav-library', views);
 _bindNav('#nav-smart',   smartViews);
 
-// Restore the last-active view (UX/UI #1 #17) — Library.showAll runs at
-// boot below, but if the user was on a different view at last reload we
-// switch to it after the initial render so they land where they were.
+// Restore the last-active view (UX/UI #1 #17).  If the user was on a non-'all'
+// view at last reload, restore it — and SKIP the boot Library.showAll() below.
+// showAll() is async (count probe → windowed render); left to run it would race
+// the restored view's own async render and, completing second, overwrite it with
+// a track list — the "Scene-groups restore shows tracks" bug.  The nav <li>s are
+// already wired (\_bindNav ran above), so we can resolve the target synchronously
+// to decide whether to suppress showAll; only the click itself is deferred.
+let _bootRestoreView = false;
 try {
   const saved = JSON.parse(localStorage.getItem('sb_last_view') || 'null');
   if (saved && saved.view && saved.view !== 'all') {
     const sel = saved.section === 'smart'
       ? `#nav-smart li[data-view="${saved.view}"]`
       : `#nav-library li[data-view="${saved.view}"]`;
-    // Defer to the next microtask so views/smartViews entries are wired.
-    Promise.resolve().then(() => {
-      const li = document.querySelector(sel);
-      if (li) li.click();
-    });
+    const li = document.querySelector(sel);
+    if (li) {
+      _bootRestoreView = true;   // synchronous → the boot showAll() below is skipped
+      Promise.resolve().then(() => {
+        _restoringBootView = true;    // activate() attaches a showAll fallback on reject
+        li.click();                   // activate runs synchronously here
+        _restoringBootView = false;
+      });
+    }
   }
 } catch {}
+
+// Reveal the "Scene groups" browse facet only when the library actually carries
+// Demozoo scene enrichment — it stays hidden (and out of the way) for a library
+// with no demoscene music, and appears once an apply/scan has populated groups.
+// Re-run after a scan completes too: the post-scan auto-apply may have landed
+// the FIRST scene data, which the boot-time check (already run) couldn't see.
+function _refreshSceneGroupsFacet() {
+  return fetch('/api/library/scene-groups', { credentials: 'same-origin' })
+    .then((r) => (r.ok ? r.json() : []))
+    .then((groups) => {
+      const li = document.querySelector('#nav-library li[data-view="scene_groups"]');
+      if (!li || !Array.isArray(groups) || !groups.length) return false;
+      li.hidden = false;
+      let badge = li.querySelector('.nav-count');
+      if (!badge) { badge = document.createElement('span'); badge.className = 'nav-count'; li.appendChild(badge); }
+      badge.textContent = groups.length.toLocaleString();
+      return true;                              // facet revealed — stop any poll
+    })
+    .catch(() => false);
+}
+// Poll the facet after a scan until the (backgrounded) post-scan Demozoo
+// auto-apply has landed its scene data, then stop.  The auto-apply settles ~10s
+// after the scan and, on a large library / modest CPU (e.g. a 4-core box with
+// 200K+ tracks), the first-ever apply can run well past any single fixed timer.
+// So instead of two guessed timeouts we walk a backoff ladder (~4 min total),
+// bailing the instant the facet reveals — or when the ladder is exhausted (a
+// library with no demoscene music, where the facet correctly stays hidden).
+function _pollSceneGroupsFacet(delays) {
+  const li = document.querySelector('#nav-library li[data-view="scene_groups"]');
+  if (li && !li.hidden) return;                 // already revealed — nothing to do
+  _refreshSceneGroupsFacet().then((revealed) => {
+    if (revealed || !delays.length) return;
+    setTimeout(() => _pollSceneGroupsFacet(delays.slice(1)), delays[0]);
+  });
+}
+_refreshSceneGroupsFacet();
 
 // ── Remote-freshness helpers ──────────────────────────────────────────────────
 //
@@ -2636,6 +2696,26 @@ requestAnimationFrame(() => {
 // once we've seen processed >= total; the moment the backend says the
 // scan is not running we flip the badge to "Done" ourselves.  Cleared
 // by any subsequent non-running scan_progress event.
+// Decide how to refresh the main panel after a scan finishes, WITHOUT stealing
+// the user's place.  A folder viewer whose folder was touched refreshes in
+// place; the canonical All-Tracks list refreshes via showAll(); every OTHER view
+// — a group list (Genres / Scene groups / …), a search result, a format filter —
+// is left exactly as-is.  A re-index must never yank the user out of where they
+// navigated.  Shared by the WS scan-complete handler, the WS embedding handler,
+// AND the HTTP stuck-badge watchdog so the three can't drift (the watchdog is
+// the fallback for a dropped final WS frame — the very case that most needs this
+// guard).  `allowAllTracksRefresh` is false for silent background freshness
+// scans, which must not reset the All-Tracks scroll position.
+function _refreshMainAfterScan(finished, allowAllTracksRefresh = true) {
+  if (Library.isInFolderView && Library.isInFolderView()) {
+    if (Library.currentFolderAffectedBy && Library.currentFolderAffectedBy(finished)) {
+      Library.refreshCurrentFolderInPlace();
+    }
+  } else if (allowAllTracksRefresh && Library.isInAllTracksView && Library.isInAllTracksView()) {
+    Library.showAll();
+  }
+}
+
 let _stuckBadgeTimer = null;
 function _armStuckBadgeWatchdog() {
   if (_stuckBadgeTimer) return;
@@ -2655,13 +2735,10 @@ function _armStuckBadgeWatchdog() {
           // Same in-place rule as the WS completion handler: don't reset a
           // folder viewer to root (the HTTP status carries last_dirs too).
           const finished = Array.isArray(st.last_dirs) ? st.last_dirs : [];
-          if (Library.isInFolderView && Library.isInFolderView()) {
-            if (Library.currentFolderAffectedBy && Library.currentFolderAffectedBy(finished)) {
-              Library.refreshCurrentFolderInPlace();
-            }
-          } else {
-            Library.showAll();
-          }
+          // Same "don't steal the user's place" rule as the WS handler — and
+          // crucially the watchdog (a dropped-final-frame fallback) must honor it
+          // too, or a group/search view is still yanked to All Tracks here.
+          _refreshMainAfterScan(finished);
           FolderTree.refresh();
         } catch (_) { /* defensive — module may not be ready */ }
       }
@@ -2762,11 +2839,10 @@ function connectWS() {
         scanBadge.hidden = false;
         scanBadge.textContent = 'Computing embeddings…';
         _disarmStuckBadgeWatchdog();
-        // Library is already usable — refresh, but don't yank a folder viewer
-        // back to root just because phase-2 embeddings started.
-        if (!(Library.isInFolderView && Library.isInFolderView())) {
-          Library.showAll();
-        }
+        // Library is already usable — refresh All Tracks in place if that's where
+        // the user is, but never yank a folder / group / search view just because
+        // phase-2 embeddings started.
+        _refreshMainAfterScan([], !msg.silent);
         // Don't rebuild the sidebar tree here — embeddings add no folders, and
         // FolderTree.refresh() collapses every expanded node back to root.
         FolderTree.setScanActive(true);
@@ -2780,6 +2856,12 @@ function connectWS() {
         _disarmStuckBadgeWatchdog();
         Library.refreshBadges();
         FolderTree.setScanActive(false);
+        // The post-scan Demozoo auto-apply runs a few seconds AFTER scan
+        // completion (backgrounded), so poll the Scene-groups facet on a backoff
+        // ladder until it lands — a library gaining its first scene data reveals
+        // the facet without a page reload, even when the apply outlasts a single
+        // fixed timer on a big library / slow box.
+        _pollSceneGroupsFacet([8000, 12000, 20000, 40000, 60000, 90000]);
         // Refresh the MAIN panel by what the user is actually looking at.
         // The old unconditional Library.showAll() reset the view to root on
         // EVERY scan completion \u2014 the "re-index finishes and I lose my place"
@@ -2788,14 +2870,15 @@ function connectWS() {
         // only a NON-silent (explicit re-index) completion with no open folder
         // falls back to showAll().  The in-place refresh runs for silent +
         // visible scans alike, so drill-down freshness updates quietly.
+        // Refresh the main panel without stealing the user's place: All Tracks in
+        // place, a touched folder in place, every other view (group list, search
+        // result, format filter) left alone.  Silent freshness scans don't
+        // refresh All Tracks (would reset scroll for a background poll).  This is
+        // also what made a boot-time scan-complete overwrite a just-restored
+        // Scene-groups view with a track list (the WS event fires seconds after a
+        // server restart).
         const finished = Array.isArray(msg.last_dirs) ? msg.last_dirs : [];
-        if (Library.isInFolderView && Library.isInFolderView()) {
-          if (Library.currentFolderAffectedBy && Library.currentFolderAffectedBy(finished)) {
-            Library.refreshCurrentFolderInPlace();
-          }
-        } else if (!msg.silent) {
-          Library.showAll();
-        }
+        _refreshMainAfterScan(finished, !msg.silent);
         // Only rebuild the sidebar tree on an EXPLICIT re-index (which may add
         // or remove roots).  A silent drill-down / freshness completion must
         // NOT \u2014 FolderTree.refresh() rebuilds from root and would collapse the
@@ -3382,7 +3465,10 @@ document.addEventListener('keydown', (e) => {
 })();
 
 // ── Init ──────────────────────────────────────────────────────────────────────
-Library.showAll();
+// Skip the default All-Tracks render when a non-'all' view is being restored
+// above — otherwise showAll()'s async windowed render races and overwrites the
+// restored view (e.g. Scene groups) with a track list.
+if (!_bootRestoreView) Library.showAll();
 FolderTree.refresh();
 // Populate the sidebar playlist list on startup.  Without this, the sidebar
 // only rendered once the user opened the right-hand playlist panel (which

--- a/soniqboom/frontend/js/library.js
+++ b/soniqboom/frontend/js/library.js
@@ -6,7 +6,7 @@
  * Exports: Library singleton
  */
 import { Player } from './player.js';
-import { artPlaceholderEmoji, ADLIB_FORMAT_NAMES, CHIP_FORMAT_NAMES, isRenderOnlyDuration, probeAdlibDurations } from './utils.js';
+import { artPlaceholderEmoji, ADLIB_FORMAT_NAMES, CHIP_FORMAT_NAMES, isRenderOnlyDuration, probeAdlibDurations, surroundLabel } from './utils.js';
 
 const API = (path, q = {}) => {
   const qs = new URLSearchParams(q).toString();
@@ -148,6 +148,34 @@ const groupFilterInput  = document.getElementById('group-filter-input');
 
 // ── State ─────────────────────────────────────────────────────────────────────
 let currentTracks = [];
+// True ONLY while the canonical All-Tracks list is the current main view — set
+// by showAll(), cleared by every other render (renderTracks default + the group
+// list).  Distinguishes All Tracks from a search result, a group drill, or a
+// format filter (all of which also flow through renderTracks / a windowed
+// store), so a post-scan refresh can update All Tracks in place without yanking
+// the user out of any other view.  Read via Library.isInAllTracksView().
+let _viewIsAllTracks = false;
+// Generation tokens for the streamed group-list / album-grid renders (their
+// rows/cards paint across animation frames): bumped by their own renderer AND by
+// renderTracks, so drilling into a track view cancels the outgoing stream's
+// pending batches instead of letting it append onto/behind the new view.
+// Declared here so renderTracks (defined above their renderers) can invalidate.
+let _groupRenderGen = 0;
+let _albumGridGen = 0;
+// Cross-view navigation generation.  Every async view-entry (group lists +
+// All Tracks) bumps this at its start and captures the value; after its fetch
+// resolves it bails if a NEWER view was requested meanwhile, so a slow first
+// fetch can't overwrite a faster second view's content (repro: click Artists
+// then Genres before /library/artists resolves — the late artist render used
+// to paint artist rows under the "Genre" header).  renderTracks bumps it too,
+// so navigating to any track view also invalidates a still-loading group list.
+let _browseNavGen = 0;
+// Identity of the smart view currently on screen, for refreshSmartOnPlay's
+// auto-refresh — recorded as the nav token at render time + the view key, so a
+// play-record refreshes ONLY the genuine History/Most-Played view, not a folder
+// or album that merely happens to share the "Most Played" crumb text.
+let _smartViewToken = -1;
+let _smartViewKey = null;
 let sortKey = null;
 let sortAsc = true;
 // Extra query params for the windowed track view (the chunked /tracks fetcher
@@ -552,7 +580,7 @@ const _CANONICAL_ROW_HTML = `
     <td class="col-track"></td>
     <td class="col-year"></td>
     <td class="col-dur"></td>
-    <td class="col-format"><span class="fmt-badge"></span></td>
+    <td class="col-format"><span class="fmt-badge"></span><span class="surround-badge" hidden></span></td>
     <td class="col-location"></td>
     <td class="col-rating"></td>`;
 
@@ -736,6 +764,21 @@ function _fillTrackRow(tr, t, i) {
   const fmtBadge = cells[9].firstElementChild;
   fmtBadge.className = `fmt-badge fmt-${_fmtClass(t.format)}`;
   fmtBadge.textContent = t.format || '';
+  // Surround marker (5.1 / 7.1 / …) — only real multichannel PCM audio, never
+  // module "voices" (see surroundLabel).  Inline, so the row height stays fixed
+  // for the virtual scroll; always toggled so a pooled row reused for a stereo
+  // track drops a prior badge.
+  const surBadge = fmtBadge.nextElementSibling;
+  if (surBadge) {                                  // defensive: never break the row render
+    const surLbl = surroundLabel(t);
+    if (surLbl) {
+      surBadge.textContent = surLbl;
+      surBadge.title = `${surLbl} surround`;
+      surBadge.hidden = false;
+    } else {
+      surBadge.hidden = true;
+    }
+  }
 
   // col-location
   const locTd = cells[10];
@@ -924,9 +967,37 @@ document.addEventListener('themechange', () => {
   _vsRender(true);
 });
 
+// Render full-search results as a flat, sortable track list.  Search used to
+// call renderTracks() directly, which leaves whatever header/filter chrome the
+// previous view set up — so searching from e.g. Genres showed the results under
+// a "Genre" colspan header with no sortable columns and a live "Filter genres…"
+// bar (typing in which wiped the results).  Restoring the full header + hiding
+// the group filter/grid toggle first makes search results always look and
+// behave like a proper track list, regardless of where the search was launched.
+function showSearchResults(tracks) {
+  hideBrowseHeader();
+  _hideGroupFilter();
+  _hideGridToggle();
+  restoreFullHeader();
+  renderTracks(tracks);
+}
+
 async function renderTracks(tracks) {
   _leaveGalaxy();          // switching to a table view exits the galaxy
   currentTracks = tracks;
+  // Cancel any in-flight group-list / album-grid stream (both paint across
+  // animation frames).  Rendering a track list — a group drill, a search, or All
+  // Tracks — means that streamed view is gone, so its pending batches must NOT
+  // keep appending stale rows/cards on top of / behind these tracks.
+  // (Repro: click a genre before its 447-row list finished streaming.)
+  _groupRenderGen++;
+  _albumGridGen++;
+  _browseNavGen++;         // a track view is now rendering → cancel any still-loading group list
+  // Default: a bare renderTracks (search result, group drill, format filter, a
+  // folder view) is NOT the canonical All-Tracks list — showAll() re-asserts the
+  // flag after it renders.  Keeps isInAllTracksView() honest for the post-scan
+  // refresh gate.
+  _viewIsAllTracks = false;
   _selected.clear();
   _lastClickIdx = -1;
   _focusedIdx   = -1;
@@ -1632,15 +1703,28 @@ function _restoreSortState() {
   document.querySelectorAll('th[data-sort]').forEach(t => {
     if (t.dataset.sort) t.setAttribute('aria-sort', 'none');
   });
+  // Restore the persisted sort STATE (sortKey/sortAsc) only — do NOT paint the
+  // header arrow here.  restoreFullHeader() runs for every flat track view
+  // (search, drills, smart, duplicates, format), but only showAll() actually
+  // re-applies the persisted sort to the data.  Painting the arrow here would
+  // show e.g. a "Year ↑" indicator over a Most-Played list ordered by play
+  // count — a lying indicator.  The view that honors the sort paints it via
+  // _paintSortIndicator().
   if (key) {
     sortKey = key;
     sortAsc = asc !== '0';
-    // Apply visual + aria indicator to the header
-    const th = document.querySelector(`th[data-sort="${sortKey}"]`);
-    if (th) {
-      th.classList.add('sorted', sortAsc ? 'sorted-asc' : 'sorted-desc');
-      _updateAriaSort(th, sortAsc);
-    }
+  }
+}
+
+// Paint the sort arrow (+ aria) for the CURRENT sortKey/sortAsc.  Called only by
+// the view that genuinely renders the data in that order (showAll), never by the
+// shared restoreFullHeader — see _restoreSortState.
+function _paintSortIndicator() {
+  if (!sortKey) return;
+  const th = document.querySelector(`th[data-sort="${sortKey}"]`);
+  if (th) {
+    th.classList.add('sorted', sortAsc ? 'sorted-asc' : 'sorted-desc');
+    _updateAriaSort(th, sortAsc);
   }
 }
 
@@ -1663,6 +1747,40 @@ function _compareTrack(a, b, key, asc) {
 // attach sites can't drift.
 function _onSortHeaderClick(th) {
   const key = th.dataset.sort;
+
+  // Windowed mode: the loaded chunks cover ~20K of N rows, so an in-memory sort
+  // would lie about positions outside the loaded window.  We round-trip to the
+  // backend, which has pre-computed sorted indexes per column (store.py
+  // _SORT_INDEX_MAP).  Keys without a backend index (track_number, path) can't
+  // sort here — bail with an explanation FIRST, before touching sort state or
+  // header classes, so a non-sortable column doesn't paint a phantom sort arrow
+  // (nor clear the real active sort's indicator).
+  // Bail FIRST (before touching sort state or header classes) for windowed views
+  // that can't be server-sorted, so we don't paint a phantom arrow or clobber the
+  // real active sort:
+  //   • keys with no backend sort index (track_number, path), OR
+  //   • a FOLDER windowed store — its rows come from /api/fstree, not /api/tracks,
+  //     so routing through _rebuildWindowedStore would refetch the WHOLE library
+  //     and replace the folder with it.  (Small folders use the in-memory path
+  //     below and DO sort correctly.)
+  const inFolder = !!(isInFolderView && isInFolderView());
+  if (currentTracks && currentTracks._isWindowedStore
+      && (!WINDOWED_SORT_KEYS.has(key) || inFolder)) {
+    if (window.Toast?.info) {
+      window.Toast.info(inFolder
+        ? 'Sorting isn’t available in a large folder view yet — open it from All Tracks to sort.'
+        : `Sort by ${key.replace('_', ' ')} isn't available in the full-library view yet.`);
+    }
+    return;
+  }
+
+  // A sort re-renders the CURRENT view reordered — it does NOT change which view
+  // we're on.  Capture the All-Tracks flag so we can restore it after the render
+  // (both _rebuildWindowedStore→renderTracks and the in-memory renderTracks clear
+  // it), or a *sorted* All-Tracks view would silently stop receiving the
+  // post-scan in-place refresh (isInAllTracksView would read false).
+  const wasAllTracks = _viewIsAllTracks;
+
   if (sortKey === key) sortAsc = !sortAsc; else { sortKey = key; sortAsc = true; }
   document.querySelectorAll('th[data-sort]').forEach(t => {
     t.classList.remove('sorted', 'sorted-asc', 'sorted-desc');
@@ -1671,29 +1789,17 @@ function _onSortHeaderClick(th) {
   _updateAriaSort(th, sortAsc);
   _saveSortState();
 
-  // Windowed mode: the loaded chunks cover ~20K of N rows, so an
-  // in-memory sort would lie about positions outside the loaded window.
-  // Round-trip to the backend instead, which has pre-computed sorted
-  // indexes per column (store.py _SORT_INDEX_MAP).  Keys without a
-  // backend index (track_number, path) toast-explain instead of producing
-  // a partial sort.
   if (currentTracks && currentTracks._isWindowedStore) {
-    if (!WINDOWED_SORT_KEYS.has(key)) {
-      if (window.Toast?.info) {
-        window.Toast.info(
-          `Sort by ${key.replace('_', ' ')} isn't available in the full-library view yet.`,
-        );
-      }
-      return;
-    }
     const total = currentTracks._total;
     _rebuildWindowedStore(total, key, sortAsc ? 'asc' : 'desc');
+    _viewIsAllTracks = wasAllTracks;
     return;
   }
 
   // Small-library path: client-side sort over the full in-memory array.
   const sorted = [...currentTracks].sort((a, b) => _compareTrack(a, b, sortKey, sortAsc));
   renderTracks(sorted);
+  _viewIsAllTracks = wasAllTracks;
 }
 
 document.querySelectorAll('#track-table th[data-sort]').forEach(th => {
@@ -1721,26 +1827,63 @@ const FULL_HEADERS = `
   <th class="col-rating">★</th>`.trim();
 
 function setGroupHeader(label) {
+  // Leaving All Tracks AND any folder view the instant a group view is entered —
+  // clear both "which view am I on" flags SYNCHRONOUSLY (before this view's async
+  // data load) so a background _refreshMainAfterScan can't see a stale
+  // isInAllTracksView()/isInFolderView()===true mid-fetch and fire showAll() /
+  // refreshCurrentFolderInPlace(), which would clobber the group nav just made.
+  // showAlbums is the only group view that doesn't also call hideBrowseHeader at
+  // entry, so without the path clear here a folder→Albums nav could be repainted
+  // with the old folder's tracks by its in-flight background scan.
+  _viewIsAllTracks = false;
+  _currentBrowsePath = null;
+  // Hide the PREVIOUS group view's filter bar synchronously on entering a new
+  // group view, so it doesn't linger through this view's async data load —
+  // navigating e.g. Scene groups → Genres used to keep the stale "Filter scene
+  // groups…" bar on screen for the whole fetch.  renderGroupList re-shows it
+  // with this view's own label + count once the data lands.
+  if (groupFilterBar) { groupFilterBar.hidden = true; if (groupFilterInput) groupFilterInput.value = ''; }
   if (!trackTableHead) return;
   trackTableHead.innerHTML = `<th colspan="12" style="font-weight:600;padding:6px 10px">${esc(label)}</th>`;
 }
 
-function restoreFullHeader() {
-  _dupViewActive = false;  // leaving duplicates view — restore user column prefs
+// Rebuild the full sortable track-table header (FULL_HEADERS + fresh sort
+// listeners + column visibility/resize).  Paints NO sort arrow (the view that
+// re-applies the sort paints it) and does NOT clear the folder path — so both a
+// non-folder view (via restoreFullHeader) and a folder view (via showFolder) can
+// present the same clean, sortable columns instead of inheriting a stale arrow
+// or a group colspan header from whatever view came before.
+function _rebuildTrackHeader() {
   if (!trackTableHead) return;
   trackTableHead.innerHTML = FULL_HEADERS;
   // Re-attach sort listeners after rebuilding the header.  Uses the same
-  // ``_onSortHeaderClick`` as the initial wire-up — single source of
-  // truth so the two attach sites can't drift on what counts as a
-  // sortable header click.
+  // ``_onSortHeaderClick`` as the initial wire-up — single source of truth so
+  // the two attach sites can't drift on what counts as a sortable header click.
   trackTableHead.querySelectorAll('th[data-sort]').forEach(th => {
     if (!th.dataset.sort) return;
     th.addEventListener('click', () => _onSortHeaderClick(th));
   });
-  // Restore persisted sort indicator
-  _restoreSortState();
   _applyColVisibility();
   _initColResize();
+}
+
+function restoreFullHeader() {
+  _dupViewActive = false;  // leaving duplicates view — restore user column prefs
+  // Leaving folder context: every non-folder flat-track view (All Tracks, drills,
+  // smart views, duplicates, "Go to artist/album" pivots, search results) calls
+  // restoreFullHeader, while showFolder does NOT — so this is the one place that
+  // reliably clears the folder path.  Without it, navigating folder → Most Played
+  // (or a pivot) left _currentBrowsePath set, so isInFolderView() stayed true and
+  // a post-scan refresh yanked the user back into the old folder.
+  _currentBrowsePath = null;
+  // Same reasoning for the All-Tracks flag: a drill / "Go to artist/album" pivot
+  // launched FROM All Tracks would otherwise leave _viewIsAllTracks true across its
+  // fetch, so a non-silent scan completion would fire showAll() and yank the user
+  // back to All Tracks.  showAll re-asserts the flag true after its own render, so
+  // clearing it here (before that) is safe.
+  _viewIsAllTracks = false;
+  _rebuildTrackHeader();
+  _restoreSortState();  // restore sortKey/sortAsc STATE + aria baseline (no paint)
 }
 
 // ── Column visibility ──────────────────────────────────────────────────────────
@@ -1868,6 +2011,7 @@ const WINDOWED_SORT_KEYS = new Set([
 ]);
 
 async function showAll() {
+  const _gen = ++_browseNavGen;
   hideBrowseHeader();
   _hideGroupFilter();
   _hideGridToggle();
@@ -1884,6 +2028,7 @@ async function showAll() {
     const { count } = await API('/tracks/count');
     total = Number(count) || 0;
   } catch { /* fall through to legacy path */ }
+  if (_gen !== _browseNavGen) return;   // a newer view was requested while probing the count
 
   if (total > limit) {
     // Pick up persisted sort state so the windowed view comes back the
@@ -1896,6 +2041,12 @@ async function showAll() {
     const sortBy    = (sortKey && WINDOWED_SORT_KEYS.has(sortKey)) ? sortKey : null;
     const sortOrder = sortBy ? (sortAsc ? 'asc' : 'desc') : null;
     _rebuildWindowedStore(total, sortBy, sortOrder);
+    _viewIsAllTracks = true;        // re-assert after renderTracks(store) cleared it
+    // Paint the sort arrow ONLY for a key the windowed store actually honors
+    // (a WINDOWED_SORT_KEY).  A persisted track_number/path key leaves the store
+    // in default order, so no arrow — restoreFullHeader no longer auto-paints it,
+    // so there is nothing stale to clear here.
+    if (sortBy) _paintSortIndicator();
     _updateNavBadge('all', total);  // exact total, no "+" needed
     return;
   }
@@ -1903,8 +2054,17 @@ async function showAll() {
   // Small-library path (≤ 5000): legacy single-fetch array — simpler,
   // no chunking overhead, no skeleton rows for unloaded slots.
   const tracks = await API('/tracks', { limit });
+  if (_gen !== _browseNavGen) return;   // a newer view was requested while fetching the page
   _showAddFolderCta = (total === 0);   // genuinely-empty library → offer the add-folder CTA
-  renderTracks(tracks);
+  // Apply the persisted sort in memory so the header arrow (painted by
+  // _restoreSortState inside restoreFullHeader) matches the data.  The small-
+  // library path renders a plain unsorted array from /tracks; the windowed path
+  // sorts server-side, and this is its ≤5000-track equivalent.  Any key works
+  // here (in-memory _compareTrack), unlike the windowed WINDOWED_SORT_KEYS set.
+  const rows = sortKey ? [...tracks].sort((a, b) => _compareTrack(a, b, sortKey, sortAsc)) : tracks;
+  renderTracks(rows);
+  _viewIsAllTracks = true;             // re-assert after renderTracks cleared it
+  if (sortKey) _paintSortIndicator();  // small path applies ANY key in memory → arrow is honest
   const truncated = tracks.length >= limit;
   _updateNavBadge('all', tracks.length, truncated);
   if (truncated) _refreshTrackCount();
@@ -1932,7 +2092,11 @@ function _rebuildWindowedStore(total, sortBy, sortOrder) {
   // When a chunk lands, re-paint the visible window so the skeleton
   // rows we showed get replaced with real data.  ``_vsRender(true)``
   // forces the render even though _vsStart/_vsEnd didn't move.
-  store.setOnChunkLoad(() => _vsRender(true));
+  // Guard the repaint on the store still being the active view: a late chunk
+  // from a windowed store the user (or a boot view-restore) has since navigated
+  // away from must NOT overwrite the new view — this is what let a slow initial
+  // All-Tracks chunk repaint tracks over a just-restored Scene-groups list.
+  store.setOnChunkLoad(() => { if (currentTracks === store) _vsRender(true); });
   // Reset scroll + selection — the indexes the user was looking at no
   // longer point at the same tracks.
   _selected.clear();
@@ -1944,15 +2108,17 @@ function _rebuildWindowedStore(total, sortBy, sortOrder) {
 }
 
 async function showArtists() {
+  const _gen = ++_browseNavGen;
   hideBrowseHeader();
   setGroupHeader('Artist');
   _hideGridToggle();
   _showSkeletonRows(12);
   const artists = await API('/library/artists');
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
   _updateNavBadge('artists', artists.length);
-  renderGroupList(artists, 'artist', 'count', 'Albums', (item) => {
+  renderGroupList(artists, 'artist', 'count', 'Tracks', (item) => {
     if (item.label || !item.artist) {
-      showUntaggedTracks('artist', '[No Artist]', () => showArtists());
+      showUntaggedTracks('artist', '[No Artist]', () => showArtists(), item.count);
     } else {
       showAlbums(item.artist, null, 'artist');
     }
@@ -1960,16 +2126,18 @@ async function showArtists() {
 }
 
 async function showAlbumArtists() {
+  const _gen = ++_browseNavGen;
   hideBrowseHeader();
   setGroupHeader('Album Artist');
   _hideGridToggle();
   _showSkeletonRows(12);
   const albumArtists = await API('/library/album-artists');
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
   _updateNavBadge('album_artists', albumArtists.length);
-  renderGroupList(albumArtists, 'album_artist', 'count', 'Albums', (item) => {
+  renderGroupList(albumArtists, 'album_artist', 'count', 'Tracks', (item) => {
     if (item.label || !item.album_artist) {
       // "[No Album Artist]" — show all untagged tracks directly
-      showUntaggedTracks('album_artist', '[No Album Artist]', () => showAlbumArtists());
+      showUntaggedTracks('album_artist', '[No Album Artist]', () => showAlbumArtists(), item.count);
     } else {
       showAlbums(null, item.album_artist, 'album_artist');
     }
@@ -1977,12 +2145,27 @@ async function showAlbumArtists() {
 }
 
 async function showAlbums(artist = null, albumArtist = null, backView = null) {
+  const _gen = ++_browseNavGen;
   const params = {};
   if (artist) params.artist = artist;
   if (albumArtist) params.album_artist = albumArtist;
   setGroupHeader('Album');
   _showSkeletonRows(12);
   const albums = await API('/library/albums', params);
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
+  // An artist / album-artist whose tracks carry no album tag yields zero album
+  // groups — drilling in would dead-end on an "No tracks found" empty state even
+  // though the artist HAS tracks (e.g. loose singles).  Fall back to the flat
+  // track list for that artist so the drill is never a dead end.
+  if (albums.length === 0 && (artist || albumArtist)) {
+    const fbBack = backView === 'album_artist'
+      ? () => showAlbumArtists()
+      : backView === 'artist'
+        ? () => showArtists()
+        : undefined;
+    if (artist) { showArtistTracks(artist, fbBack); return; }
+    if (albumArtist) { showAlbumArtistTracks(albumArtist, fbBack); return; }
+  }
   if (!artist && !albumArtist) _updateNavBadge('albums', albums.length);
   const backLabel = artist || albumArtist || null;
   const backFn = backView === 'album_artist'
@@ -1999,14 +2182,15 @@ async function showAlbums(artist = null, albumArtist = null, backView = null) {
     const backTo = () => showAlbums(artist, albumArtist, backView);
     if (item.label || !item.album) {
       // "[No Album]" — show tracks without album metadata
-      showUntaggedTracks('album', '[No Album]', backTo);
+      showUntaggedTracks('album', '[No Album]', backTo, item.count);
     } else {
       showAlbumTracks(item.artist, item.album_artist, item.album, backTo);
     }
   });
 }
 
-async function showUntaggedTracks(field, label, backFn) {
+async function showUntaggedTracks(field, label, backFn, total = 0) {
+  const _gen = ++_browseNavGen;
   _hideGroupFilter();
   _hideGridToggle();
   restoreFullHeader();
@@ -2014,11 +2198,18 @@ async function showUntaggedTracks(field, label, backFn) {
   _showSkeletonRows();
   // Fetch a large batch and filter client-side (tag index can't query empty fields)
   const all = await API('/tracks', { limit: 5000 });
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
   const filtered = all.filter(t => !t[field] || !t[field].toString().trim());
   renderTracks(filtered);
+  // This drill fetches only the first 5,000 tracks and filters client-side, so a
+  // large untagged set (e.g. 200k+ mod/SID files with no album-artist) is shown
+  // only partially.  Disclose the shortfall in the crumb like every other capped
+  // drill instead of silently implying the (now accurate) badge count is listed.
+  _noteDrillCap(filtered.length, total);
 }
 
 async function showAlbumTracks(artist, albumArtist, album, backFn) {
+  const _gen = ++_browseNavGen;
   _hideGroupFilter();
   _hideGridToggle();
   restoreFullHeader();
@@ -2028,11 +2219,12 @@ async function showAlbumTracks(artist, albumArtist, album, backFn) {
   setBrowseHeader(label, backFn || (() => showAlbums()));
   _showSkeletonRows();
   // Build filter params — omit empty/null values so the API isn't confused
-  const params = { limit: 500 };
+  const params = { limit: _DRILL_LIMIT };
   if (albumArtist) params.album_artist = albumArtist;
   else if (artist) params.artist = artist;
   if (album) params.album = album;
   const tracks = await API('/search/filter', params);
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
   // Sort by disc number, then track number (album track order)
   tracks.sort((a, b) => {
     const da = a.disc_number ?? 0, db = b.disc_number ?? 0;
@@ -2041,18 +2233,38 @@ async function showAlbumTracks(artist, albumArtist, album, backFn) {
     return ta - tb;
   });
   renderTracks(tracks);
+  _noteDrillCap(tracks.length);            // album total unknown here → generic cue if capped
 }
 
 // "Go to artist" — every track by this artist as a track list.  Used by the
 // track context menu so you can pivot from one track to the whole artist.
 async function showArtistTracks(artist, backFn) {
+  const _gen = ++_browseNavGen;
   _hideGroupFilter();
   _hideGridToggle();
   restoreFullHeader();
   setBrowseHeader(`Artist: ${artist}`, backFn || (() => showArtists()));
   _showSkeletonRows();
-  const tracks = await API('/search/filter', { limit: 500, artist });
+  const tracks = await API('/search/filter', { limit: _DRILL_LIMIT, artist });
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
   renderTracks(tracks);
+  _noteDrillCap(tracks.length);            // artist total unknown here → generic cue if capped
+}
+
+// Flat track list for an album-artist.  Mirrors showArtistTracks; used as the
+// zero-album fallback in showAlbums so an album-artist whose tracks have no
+// album tag still resolves to its tracks instead of an empty album view.
+async function showAlbumArtistTracks(albumArtist, backFn) {
+  const _gen = ++_browseNavGen;
+  _hideGroupFilter();
+  _hideGridToggle();
+  restoreFullHeader();
+  setBrowseHeader(`Album Artist: ${albumArtist}`, backFn || (() => showAlbumArtists()));
+  _showSkeletonRows();
+  const tracks = await API('/search/filter', { limit: _DRILL_LIMIT, album_artist: albumArtist });
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
+  renderTracks(tracks);
+  _noteDrillCap(tracks.length);
 }
 
 // Snapshot the current view so a "Go to …" navigation can offer a Back that
@@ -2088,33 +2300,96 @@ function _goToAlbum(t) {
 }
 
 async function showGenres() {
+  const _gen = ++_browseNavGen;
   hideBrowseHeader();
   setGroupHeader('Genre');
   _hideGridToggle();
   _showSkeletonRows(12);
   const genres = await API('/library/genres');
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
   _updateNavBadge('genres', genres.length);
-  renderGroupList(genres, 'genre', 'count', 'Tracks', (item) => showGenreTracks(item.genre));
+  renderGroupList(genres, 'genre', 'count', 'Tracks', (item) => showGenreTracks(item.genre, item.count));
 }
 
-async function showGenreTracks(genre) {
+// Drill-down fetch ceiling — the /search/filter endpoint's `le` bound.  The
+// row list is virtual-scrolled (see createWindowedStore / _vsRender), so a full
+// facet only holds track dicts in memory, not DOM rows.
+const _DRILL_LIMIT = 2000;
+
+// Append an honest capped-list note to the browse crumb when a drill-down is
+// bigger than the fetch ceiling, so a giant facet (e.g. a 124K-track "Module"
+// genre, or a prolific composer's "every track" pivot) renders a visibly-capped
+// list rather than silently dropping the overflow — the count-vs-list mismatch
+// the user would otherwise hit after clicking a row whose badge promised far
+// more.  Two modes: when the true total is known (facet rows carry a count) the
+// note is precise ("of 124,738"); when it isn't (artist/album pivots don't
+// pre-know the size) the note fires only once the fetch actually hit the ceiling.
+// Scene groups top out well under the ceiling, so this note never shows for them.
+function _noteDrillCap(shown, total = 0) {
+  let note = '';
+  if (total > 0) {
+    if (shown >= total) return;
+    note = ` — showing first ${shown.toLocaleString()} of ${total.toLocaleString()} (refine to narrow)`;
+  } else if (shown >= _DRILL_LIMIT) {
+    note = ` — showing first ${shown.toLocaleString()} (refine to narrow)`;
+  } else {
+    return;
+  }
+  try { browseCrumb.textContent += note; } catch (_) { /* crumb missing — non-fatal */ }
+}
+
+async function showGenreTracks(genre, total = 0) {
+  const _gen = ++_browseNavGen;
   _hideGroupFilter();
   _hideGridToggle();
   restoreFullHeader();
   setBrowseHeader(`Genre: ${genre}`, () => showGenres());
   _showSkeletonRows();
-  const tracks = await API('/search/filter', { genre, limit: 500 });
+  const tracks = await API('/search/filter', { genre, limit: _DRILL_LIMIT });
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
   renderTracks(tracks);
+  _noteDrillCap(tracks.length, total);
 }
 
 async function showYears() {
+  const _gen = ++_browseNavGen;
   hideBrowseHeader();
   setGroupHeader('Year');
   _hideGridToggle();
   _showSkeletonRows(12);
   const years = await API('/library/years');
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
   _updateNavBadge('years', years.length);
-  renderGroupList(years, 'year', 'count', 'Tracks', (item) => showYearTracks(item.year));
+  renderGroupList(years, 'year', 'count', 'Tracks', (item) => showYearTracks(item.year, item.count));
+}
+
+async function showSceneGroups() {
+  const _gen = ++_browseNavGen;
+  hideBrowseHeader();
+  setGroupHeader('Scene group');
+  _hideGridToggle();
+  _showSkeletonRows(12);
+  const groups = await API('/library/scene-groups');
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
+  _updateNavBadge('scene_groups', groups.length);
+  renderGroupList(groups, 'scene_group', 'count', 'Tracks',
+                  (item) => showSceneGroupTracks(item.scene_group, item.count));
+}
+
+async function showSceneGroupTracks(scene_group, total = 0) {
+  const _gen = ++_browseNavGen;
+  _hideGroupFilter();
+  _hideGridToggle();
+  restoreFullHeader();
+  setBrowseHeader(`Scene group: ${scene_group}`, () => showSceneGroups());
+  _showSkeletonRows();
+  // Keeps the drill-down list consistent with the group-row count the user just
+  // clicked — the biggest scene groups here run ~1.7K tracks, well under
+  // _DRILL_LIMIT, so the whole group renders and _noteDrillCap stays silent.
+  const tracks = await API('/search/filter', { scene_group, limit: _DRILL_LIMIT });
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
+  renderTracks(tracks);
+  _noteDrillCap(tracks.length, total);
 }
 
 // ── Library Galaxy view (viz #6) ──────────────────────────────────────────
@@ -2126,9 +2401,19 @@ function _leaveGalaxy() {
   if (wrap) wrap.style.display = '';
 }
 async function showGalaxy() {
+  // Bump the nav token even though Galaxy renders no track list: a group/drill/
+  // smart fetch still in flight when the user clicks Galaxy would otherwise pass
+  // its own guard (token unchanged) and its renderGroupList/renderTracks would
+  // call _leaveGalaxy(), yanking the user back out of the Galaxy they just opened.
+  const _gen = ++_browseNavGen;
   hideBrowseHeader();
   _hideGroupFilter();
   _hideGridToggle();
+  // Galaxy is a canvas viz, not a track list — it never goes through
+  // renderTracks(), so clear the All-Tracks flag explicitly.  Otherwise, coming
+  // from All Tracks, a post-scan refresh would think we're still on All Tracks
+  // and renderTracks/_leaveGalaxy would yank the user out of the Galaxy view.
+  _viewIsAllTracks = false;
   setGroupHeader('Galaxy');
   // Hide the table surfaces, reveal the galaxy canvas host.
   const wrap = document.getElementById('track-list-wrap');
@@ -2140,6 +2425,7 @@ async function showGalaxy() {
   // Lazy-mount; clicking a cluster filters the library to that format.
   if (!_galaxy && view) {
     const { mountGalaxy } = await import('./viz/galaxy.js');
+    if (_gen !== _browseNavGen) return;   // superseded during the (first-mount) import
     _galaxy = mountGalaxy(view, {
       onPickFormat: (fmt, count) => showFormatTracks(fmt, count),
     });
@@ -2148,6 +2434,7 @@ async function showGalaxy() {
   }
 }
 async function showFormatTracks(format, count = 0) {
+  const _gen = ++_browseNavGen;
   restoreFullHeader();
   setBrowseHeader(`Format: ${format}`, () => showGalaxy());
   _hideGridToggle();
@@ -2166,25 +2453,38 @@ async function showFormatTracks(format, count = 0) {
       total = hit ? Number(hit.count) || 0 : 0;
     } catch { /* fall through to single-fetch */ }
   }
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while probing the count
   if (total > WINDOW_THRESHOLD) {
     const sortBy    = (sortKey && WINDOWED_SORT_KEYS.has(sortKey)) ? sortKey : null;
     const sortOrder = sortBy ? (sortAsc ? 'asc' : 'desc') : null;
     _rebuildWindowedStore(total, sortBy, sortOrder);   // renders the windowed store
+    // The store fetched server-SORTED chunks, so paint the arrow to match — same
+    // as showAll's windowed branch (restoreFullHeader no longer auto-paints it).
+    if (sortBy) _paintSortIndicator();
     return;
   }
-  // Small format: a single format-filtered fetch (no chunking overhead).
+  // Small format: a single format-filtered fetch (no chunking overhead).  Apply
+  // the persisted sort in memory + paint the arrow, mirroring showAll's small
+  // path AND the windowed format branch above — so the same "Format:" view sorts
+  // consistently regardless of size.
   const tracks = await API('/tracks', { format, limit: WINDOW_THRESHOLD });
-  renderTracks(tracks);
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
+  const rows = sortKey ? [...tracks].sort((a, b) => _compareTrack(a, b, sortKey, sortAsc)) : tracks;
+  renderTracks(rows);
+  if (sortKey) _paintSortIndicator();
 }
 
-async function showYearTracks(year) {
+async function showYearTracks(year, total = 0) {
+  const _gen = ++_browseNavGen;
   _hideGroupFilter();
   _hideGridToggle();
   restoreFullHeader();
   setBrowseHeader(`Year: ${year}`, () => showYears());
   _showSkeletonRows();
-  const tracks = await API('/search/filter', { year_min: year, year_max: year, limit: 500 });
+  const tracks = await API('/search/filter', { year_min: year, year_max: year, limit: _DRILL_LIMIT });
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
   renderTracks(tracks);
+  _noteDrillCap(tracks.length, total);
 }
 
 // ── Grid toggle helpers ────────────────────────────────────────────────────────
@@ -2236,7 +2536,6 @@ function _loadAlbumCardArt(card, trackId) {
 // tens of thousands of one-track SID/MOD "albums" no longer freeze the thread
 // on the flip to grid or attach 100k+ listeners.  Focus ring is pure CSS
 // (.album-card:focus-visible), so no per-card focus/blur handlers either.
-let _albumGridGen = 0;
 let _albumGridItems = [];
 let _albumGridOnClick = null;
 let _albumGridWired = false;
@@ -2276,6 +2575,13 @@ function _wireAlbumGridDelegation(albumGrid) {
     const item = itemOf(e.target);
     if (item) { e.preventDefault(); _albumGridOnClick?.(item); }
   });
+}
+
+// Pluralise a group-row count label: "1 Album" / "2 Albums", "1 Track" /
+// "3 Tracks".  countLabel is stored plural; drop the trailing "s" when the
+// count is exactly 1 so single-item rows read grammatically.
+function _countText(n, countLabel) {
+  return `${n} ${n === 1 ? countLabel.replace(/s$/, '') : countLabel}`;
 }
 
 function _renderAlbumGrid(items, nameKey, countKey, countLabel, onClick) {
@@ -2351,7 +2657,7 @@ function _renderAlbumGrid(items, nameKey, countKey, countLabel, onClick) {
       // Cards behave like buttons; the focus ring is CSS :focus-visible.
       card.tabIndex = 0;
       card.setAttribute('role', 'button');
-      card.setAttribute('aria-label', `${name}, ${count} ${countLabel}`);
+      card.setAttribute('aria-label', `${name}, ${_countText(count, countLabel)}`);
       card.innerHTML = `
         <div class="album-card-art">
           <span class="album-card-initials">${esc(initials)}</span>
@@ -2359,7 +2665,7 @@ function _renderAlbumGrid(items, nameKey, countKey, countLabel, onClick) {
         </div>
         <div class="album-card-info">
           <div class="album-card-title" title="${esc(name)}">${esc(name)}</div>
-          <div class="album-card-sub">${count} ${countLabel}</div>
+          <div class="album-card-sub">${_countText(count, countLabel)}</div>
         </div>`;
       frag.appendChild(card);
       _albumArtObserver.observe(card);      // lazy art; fires once connected + visible
@@ -2381,6 +2687,7 @@ function renderGroupList(items, nameKey, countKey, countLabel, onClick, showFilt
   _groupOnClick  = onClick;
 
   currentTracks = [];
+  _viewIsAllTracks = false;   // a group list is not the All-Tracks view
   loadingEl.hidden = true;
   emptyEl.hidden = items.length > 0;
 
@@ -2403,8 +2710,9 @@ function renderGroupList(items, nameKey, countKey, countLabel, onClick, showFilt
         : nameKey === 'album' ? 'Albums'
         : nameKey === 'genre' ? 'Genres'
         : nameKey === 'year' ? 'Years'
+        : nameKey === 'scene_group' ? 'Scene groups'
         : nameKey.charAt(0).toUpperCase() + nameKey.slice(1);
-      groupFilterLabel.textContent = `${items.length} ${viewLabel}`;
+      groupFilterLabel.textContent = `${items.length.toLocaleString()} ${viewLabel}`;
       groupFilterInput.value = '';
       groupFilterInput.placeholder = `Filter ${viewLabel.toLowerCase()}…`;
       groupFilterBar.hidden = false;
@@ -2437,8 +2745,6 @@ function renderGroupList(items, nameKey, countKey, countLabel, onClick, showFilt
   _updateAzRail();
 }
 
-let _groupRenderGen = 0;
-
 function _renderGroupRows(items, nameKey, countKey, countLabel, onClick) {
   // Group rows replace the tbody — drop any pool nodes that were here.
   _vsResetPool();
@@ -2456,7 +2762,7 @@ function _renderGroupRows(items, nameKey, countKey, countLabel, onClick) {
       <td class="col-num"></td>
       <td class="col-cover"></td>
       <td class="col-title" colspan="7" style="font-weight:500;${item.label ? 'font-style:italic;color:var(--text2)' : ''}">${esc(item.label || item[nameKey] || '—')}</td>
-      <td class="col-dur" style="color:var(--text2)">${item[countKey]} ${countLabel}</td>
+      <td class="col-dur" style="color:var(--text2)">${_countText(item[countKey] || 0, countLabel)}</td>
       <td class="col-rating"></td>`;
     tr.style.cursor = 'pointer';
     tr.addEventListener('click', () => onClick(item));
@@ -2963,12 +3269,30 @@ Player.on('trackchange', (track) => {
 });
 
 async function showFolder(path, recursive = false, opts = {}) {
+  // A real folder navigation bumps the nav token; a quiet in-place refresh only
+  // CAPTURES it (no bump) so it stays a background op — but it still bails below
+  // if the user navigated to another view during its fetch.  (_sameTrackList
+  // compares against the NEW view's currentTracks, so it can't catch that on its
+  // own — a quiet refresh landing under a genre list would wipe it otherwise.)
+  const _gen = opts.quiet ? _browseNavGen : ++_browseNavGen;
   _currentBrowsePath = path;
+  _viewIsAllTracks = false;   // a folder is never All Tracks — keep both flags consistent
+                              // (showFolder doesn't call restoreFullHeader, which is where
+                              // the other flat-track views clear this)
   _currentBrowseRecursive = recursive;
   _hideGridToggle();
   // ``opts.quiet`` = an in-place freshness refresh (not a user navigation):
   // skip the skeleton flash and don't re-schedule another background scan.
-  if (!opts.quiet) _showSkeletonRows();
+  if (!opts.quiet) {
+    // Present clean, sortable track columns — a folder must not inherit a stale
+    // sort arrow (folders render in /api/fstree order, not the persisted sort)
+    // or a group colspan header from whatever view came before.  Rebuild here
+    // rather than via restoreFullHeader so the folder path we just set is kept.
+    // (Skipped on the quiet in-place refresh so it doesn't reset column widths.)
+    _rebuildTrackHeader();
+    _hideGroupFilter();
+    _showSkeletonRows();
+  }
 
   setBrowseHeader(path.split('/').filter(Boolean).pop() || path, () => {
     hideBrowseHeader();
@@ -3027,6 +3351,7 @@ async function showFolder(path, recursive = false, opts = {}) {
     const firstChunk = windowed
       ? (Array.isArray(first.tracks) ? first.tracks : [])
       : (Array.isArray(first) ? first : []);
+    if (_gen !== _browseNavGen) return;   // superseded by a newer view (or nav during a quiet refresh)
 
     // Branch-folder case: the clicked directory has no DIRECT audio
     // (e.g. ``modarchive_2007`` root holds only zip subfolders).  Auto-flatten
@@ -3039,8 +3364,21 @@ async function showFolder(path, recursive = false, opts = {}) {
     // Whole folder fit in the first chunk → render it directly (the common
     // album-sized case; no windowed store needed).
     if (total <= firstChunk.length) {
-      if (opts.quiet && _sameTrackList(firstChunk, currentTracks)) return;
-      renderTracks(firstChunk);
+      // Preserve a sort the user applied to THIS folder across a quiet freshness
+      // refresh.  A small folder is sortable in memory (see _onSortHeaderClick),
+      // which paints an arrow for sortKey; the fresh chunk comes back in fstree
+      // order.  If that arrow is currently painted, re-apply the sort so the rows
+      // keep matching it — otherwise a background scan would silently snap the
+      // folder back to disk order and leave the arrow lying.  (A freshly-entered,
+      // unsorted folder has no arrow — _rebuildTrackHeader cleared it — so it
+      // correctly renders in fstree order.)
+      const folderSorted = sortKey && trackTableHead &&
+        trackTableHead.querySelector(`th[data-sort="${sortKey}"].sorted`);
+      const rows = folderSorted
+        ? [...firstChunk].sort((a, b) => _compareTrack(a, b, sortKey, sortAsc))
+        : firstChunk;
+      if (opts.quiet && _sameTrackList(rows, currentTracks)) return;
+      renderTracks(rows);
       if (!opts.quiet) _scheduleBackgroundRefresh(path);
       return;
     }
@@ -3079,6 +3417,16 @@ async function showFolder(path, recursive = false, opts = {}) {
  * ``_has_audio`` — directory-level, not track-level dedup.)
  */
 async function _showFolderRecursiveWindowed(path, opts = {}, recursive = true, prefetched = null) {
+  const _gen = opts.quiet ? _browseNavGen : ++_browseNavGen;   // quiet = capture only, still bails on nav-away
+  // A windowed folder renders fstree-order chunks and is never sorted (the sort
+  // handler bails for windowed folders), so clear any painted sort arrow — the
+  // quiet in-place refresh skips _rebuildTrackHeader, so a sorted small folder a
+  // background scan grows past the chunk threshold would otherwise land here with
+  // a stale arrow lying over unsorted rows.
+  if (trackTableHead) trackTableHead.querySelectorAll('th[data-sort]').forEach(t => {
+    t.classList.remove('sorted', 'sorted-asc', 'sorted-desc');
+    if (t.dataset.sort) t.setAttribute('aria-sort', 'none');
+  });
   const enc = encodeURIComponent(path);
   // Non-recursive (a single leaf folder with thousands of direct tracks, e.g.
   // an archive bucket) collapses duplicate groups server-side, matching the
@@ -3097,6 +3445,7 @@ async function _showFolderRecursiveWindowed(path, opts = {}, recursive = true, p
       return;
     }
   }
+  if (_gen !== _browseNavGen) return;   // superseded by a newer view (or nav during a quiet refresh)
   const total      = Number(firstRes?.total || 0);
   const firstChunk = Array.isArray(firstRes?.tracks) ? firstRes.tracks : [];
 
@@ -3130,7 +3479,11 @@ async function _showFolderRecursiveWindowed(path, opts = {}, recursive = true, p
   // Preload chunk 0 from the first response so ``fetchChunk(0)``
   // short-circuits the moment ``_vsRender`` reaches into the store.
   store._chunks.set(0, firstChunk);
-  store.setOnChunkLoad(() => _vsRender(true));
+  // Guard the repaint on the store still being the active view: a late chunk
+  // from a windowed store the user (or a boot view-restore) has since navigated
+  // away from must NOT overwrite the new view — this is what let a slow initial
+  // All-Tracks chunk repaint tracks over a just-restored Scene-groups list.
+  store.setOnChunkLoad(() => { if (currentTracks === store) _vsRender(true); });
   // Reset scroll + selection — the indexes the user was looking at no
   // longer point at the same tracks.
   _selected.clear();
@@ -3202,6 +3555,9 @@ function clearSelection() {
  * @param {string} label  Human-readable heading for the browse header
  */
 async function showSmart(view, label) {
+  const _gen = ++_browseNavGen;
+  _viewIsAllTracks = false;   // leave All Tracks synchronously so a mid-fetch scan
+                              // refresh can't fire showAll() and clobber this view
   _hideGroupFilter();
   _hideGridToggle();
   restoreFullHeader();
@@ -3213,6 +3569,7 @@ async function showSmart(view, label) {
     const res = await fetch(url);
     if (!res.ok) throw new Error(`${res.status}`);
     const data = await res.json();
+    if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
 
     if (view === 'history') {
       // History returns [{track_id, title, artist, ts}, ...]
@@ -3234,16 +3591,20 @@ async function showSmart(view, label) {
         });
         allTracks = r.ok ? await r.json() : [];
       } catch { allTracks = []; }
+      if (_gen !== _browseNavGen) return;   // superseded during the history hydrate
       const trackMap = Object.fromEntries(allTracks.map(t => [t.id, t]));
       // Maintain history order (newest first)
       const ordered = data.map(h => trackMap[h.track_id]).filter(Boolean);
       renderTracks(ordered);
+      _smartViewToken = _browseNavGen; _smartViewKey = view;   // this render is the live smart view
     } else {
       // All other smart views return track arrays directly
       renderTracks(Array.isArray(data) ? data : []);
+      _smartViewToken = _browseNavGen; _smartViewKey = view;
     }
   } catch (err) {
     console.error('Smart view fetch failed:', err);
+    if (_gen !== _browseNavGen) return;   // superseded — don't clobber the newer view
     renderTracks([]);
   }
 }
@@ -3253,10 +3614,14 @@ async function showSmart(view, label) {
 // has no server push).  Keyed off the live browse-crumb so there's no stale
 // active-view state to get wrong; a no-op unless one of those views is showing.
 function refreshSmartOnPlay() {
-  if (browseHdr.hidden) return;
-  const crumb = (browseCrumb.textContent || '').trim();
-  if (crumb === 'Listening History') showSmart('history', 'Listening History');
-  else if (crumb === 'Most Played')  showSmart('most-played', 'Most Played');
+  // Gate on the recorded view IDENTITY (nav token), NOT the crumb text — a folder
+  // or bare-titled album named "Most Played" shares the crumb but is not the smart
+  // view, and refreshing it would clobber the user's actual view.  The token goes
+  // stale the moment any other view renders (each bumps _browseNavGen), so this
+  // fires only while the genuine History / Most-Played smart list is on screen.
+  if (browseHdr.hidden || _smartViewToken !== _browseNavGen) return;
+  if (_smartViewKey === 'history')          showSmart('history', 'Listening History');
+  else if (_smartViewKey === 'most-played') showSmart('most-played', 'Most Played');
 }
 
 
@@ -3303,6 +3668,8 @@ function _exportCSV(tracks, filename = 'soniqboom-export.csv') {
  * with the primary track shown and variants collapsed beneath.
  */
 async function showDuplicates() {
+  const _gen = ++_browseNavGen;
+  _viewIsAllTracks = false;   // leave All Tracks synchronously (see showSmart)
   _hideGroupFilter();
   _hideGridToggle();
   restoreFullHeader();
@@ -3314,6 +3681,7 @@ async function showDuplicates() {
     const res = await fetch('/api/smart/duplicates?limit=200');
     if (!res.ok) throw new Error(`${res.status}`);
     const groups = await res.json();
+    if (_gen !== _browseNavGen) return;   // superseded by a newer view while fetching
 
     if (!groups.length) {
       renderTracks([]);
@@ -3353,6 +3721,7 @@ async function showDuplicates() {
     _showExportBtn(() => _exportCSV(flatTracks, 'soniqboom-duplicates.csv'));
   } catch (err) {
     console.error('Duplicates fetch failed:', err);
+    if (_gen !== _browseNavGen) return;   // superseded — don't clobber the newer view
     renderTracks([]);
   }
 }
@@ -3478,8 +3847,23 @@ function patchTrackDuration(id, seconds) {
 export const Library = {
   patchTrackDuration,
   showAll, showArtists, showAlbumArtists, showAlbums, showAlbumTracks,
-  showGenres, showYears, showGalaxy, showFolder, renderTracks,
+  showGenres, showYears, showSceneGroups, showGalaxy, showFolder, renderTracks,
+  showSearchResults,
+  // Cross-view render-race token: an async caller in another module (search.js)
+  // captures it before its fetch and bails if a newer view superseded it, the
+  // same guard the in-file views use — so a search that resolves after the user
+  // clicked a nav facet no longer paints results over that facet.
+  beginView: () => {
+    // Search is leaving All Tracks / any folder: clear both flags synchronously
+    // (before the /api/search fetch) so a scan completing mid-search can't fire
+    // showAll()/refreshCurrentFolderInPlace() and clobber the pending results.
+    _viewIsAllTracks = false;
+    _currentBrowsePath = null;
+    return ++_browseNavGen;
+  },
+  viewStillCurrent: (t) => t === _browseNavGen,
   isInFolderView, currentFolderAffectedBy, refreshCurrentFolderInPlace,
+  isInAllTracksView: () => _viewIsAllTracks,
   setBrowseHeader, hideBrowseHeader, onInfo,
   getSelectedTracks, clearSelection, refreshBadges: _refreshTrackCount,
   // Smart & duplicates views

--- a/soniqboom/frontend/js/playlist.js
+++ b/soniqboom/frontend/js/playlist.js
@@ -282,9 +282,10 @@ async function _openPlaylist(id, name, _focusPanel = true) {
   // view visible so the user sees the existing playlists rather than a
   // "0 tracks" empty-state that looks identical to a real empty playlist.
   let loadFailed = false;
+  let loadedTracks = [];
   try {
-    const data    = await _api(`/playlists/${id}`);
-    _activeTracks = data.tracks || [];
+    const data   = await _api(`/playlists/${id}`);
+    loadedTracks = data.tracks || [];
   } catch (err) {
     loadFailed = true;
     console.warn('Failed to open playlist:', err);
@@ -295,6 +296,13 @@ async function _openPlaylist(id, name, _focusPanel = true) {
     _activeId = null;
     return;
   }
+
+  // A newer _openPlaylist (rapid A→B) may have superseded this one while it
+  // loaded — _activeId now points at B.  Bail BEFORE mutating shared state so B's
+  // slower load isn't overwritten by A's tracks (a later re-render would paint
+  // A's tracks under B's header) or panel.
+  if (_activeId !== id) return;
+  _activeTracks = loadedTracks;   // commit only after confirming we're still current
 
   plActiveNm.textContent = name;
   plActiveCt.textContent = `${_activeTracks.length} track${_activeTracks.length !== 1 ? 's' : ''}`;

--- a/soniqboom/frontend/js/search.js
+++ b/soniqboom/frontend/js/search.js
@@ -301,9 +301,18 @@ function _fmtDur(sec) {
 // what looks like an operator (``word:value``) that isn't one we know
 // about, we highlight that token red so the user understands why the
 // preview is empty.
+// EXACTLY the operators the backend advanced-query parser implements
+// (api/search.py _parse_advanced_query: artist, album_artist, album, genre,
+// year, format).  title:/composer:/albumartist: used to be listed here too but
+// the backend silently discards them — a query like `artist:Metallica title:One`
+// returned all Metallica tracks, ignoring the title.  Keeping this in lockstep
+// with the backend means unsupported fields now surface an honest "Unknown
+// field" hint instead of wrong results; plain free-text search still matches
+// title/composer text, so nothing is lost.  If the backend gains a field, add
+// it here in the same change.
 const _SUPPORTED_OPS = new Set([
-  'artist', 'album_artist', 'albumartist', 'album',
-  'year', 'genre', 'format', 'title', 'composer',
+  'artist', 'album_artist', 'album',
+  'year', 'genre', 'format',
 ]);
 let _syntaxHintShown = false;
 
@@ -355,13 +364,22 @@ function _renderBadOpsWarning(container, badOps) {
 async function query(text) {
   _hidePreview();
   if (!text.trim()) { Library.showAll(); return; }
+  // A full search is a view change: claim the cross-view nav token so that if the
+  // user clicks a nav facet before results land, the late results don't paint over
+  // that facet (search → nav render race).
+  const _tok = Library.beginView();
   // Previously an uncaught fetch/json error here left the library blank with
   // no explanation.  Surface failures and keep the prior view intact.
   try {
     const res = await fetch(`/api/search?q=${encodeURIComponent(text)}&limit=200`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const tracks = await res.json();
-    Library.renderTracks(tracks);
+    if (!Library.viewStillCurrent(_tok)) return;   // superseded by a newer view while searching
+    // showSearchResults (not bare renderTracks) so results always render as a
+    // proper sortable track list with the group header/filter chrome cleared —
+    // otherwise a search launched from a group view (Genres, Scene groups, …)
+    // shows the results under that view's stale header + live filter bar.
+    Library.showSearchResults(tracks);
   } catch (err) {
     console.error('Search failed:', err);
     Toast.error('Search failed — check the server log.');
@@ -493,6 +511,24 @@ input.addEventListener('focus', () => {
     _syntaxHintShown = true;
   }
 });
+
+// ── Edge password-manager suppression ────────────────────────────────────────
+// Edge's built-in password manager offers the site's saved LOGIN on any field it
+// classifies as a username — which, only in Edge, includes this search box: it
+// ignores the type="search" + autocomplete="off" hints that keep Safari/Firefox
+// (and Chrome) out of the way, because a logged-in SPA has no visible login form
+// for it to target.  Autofill never fires on a READONLY field, so the box starts
+// readonly (see index.html) and we drop that the instant the user actually acts —
+// keydown fires BEFORE the character is inserted, so the first keystroke is not
+// lost, and contextmenu covers right-click → Paste.  Re-armed on blur so the box
+// is readonly again at every focus (the moment Edge decides whether to offer).
+// Programmatic changes (the clear button, search restore) set .value directly and
+// are unaffected — readonly only blocks USER text entry, not scripted writes.
+const _armSearchReadonly  = () => input.setAttribute('readonly', '');
+const _dropSearchReadonly = () => input.removeAttribute('readonly');
+input.addEventListener('keydown', _dropSearchReadonly);
+input.addEventListener('contextmenu', _dropSearchReadonly);
+input.addEventListener('blur', _armSearchReadonly);
 
 clear.addEventListener('click', () => {
   input.value = '';

--- a/soniqboom/frontend/js/stations.js
+++ b/soniqboom/frontend/js/stations.js
@@ -697,6 +697,7 @@ const _BUCKETS = [
 ];
 
 async function _renderCountry(cont, country, bucket = 'top10') {
+  const gen = _renderGen;   // top-level view-switch guard (matches the sibling renderers)
   _setCrumbs([
     { label: 'World', fn: _renderWorld },
     { label: cont.continent, fn: () => _renderContinent(cont) },
@@ -706,16 +707,20 @@ async function _renderCountry(cont, country, bucket = 'top10') {
   body.innerHTML = `<div class="st-tabs">${_BUCKETS.map(([k, lbl]) =>
     `<button class="st-tab ${k === bucket ? 'on' : ''}" data-b="${k}">${lbl}</button>`).join('')}
     </div><div class="st-tab-body"><div class="st-empty">Loading…</div></div>`;
+  // Capture THIS render's tab-body: a rapid bucket switch (or country re-select)
+  // replaces it, so a late fetch must not fill a tab-body that's been detached.
+  const tb = body.querySelector('.st-tab-body');
   body.querySelectorAll('.st-tab').forEach((b) => {
     b.addEventListener('click', () => _renderCountry(cont, country, b.dataset.b));
   });
   try {
     const stations = await _fetchJson(
       `/api/stations/country/${encodeURIComponent(country.code)}?bucket=${bucket}`);
-    _stationRows(body.querySelector('.st-tab-body'), stations);
+    if (gen !== _renderGen || !tb.isConnected) return;   // superseded by a newer view / bucket
+    _stationRows(tb, stations);
   } catch (e) {
-    const tb = body.querySelector('.st-tab-body');
-    if (tb) tb.innerHTML = `<div class="st-empty">Could not load: ${esc(e.message)}</div>`;
+    if (gen !== _renderGen || !tb.isConnected) return;
+    tb.innerHTML = `<div class="st-empty">Could not load: ${esc(e.message)}</div>`;
   }
 }
 

--- a/soniqboom/frontend/js/trackinfo.js
+++ b/soniqboom/frontend/js/trackinfo.js
@@ -12,7 +12,7 @@
  *   TrackInfo.openSingle(track)        — open panel for a single track
  */
 import { Player }              from './player.js';
-import { artPlaceholderEmoji, trapFocus, isUadeAmigaTrack, ATARI_FORMAT_NAMES, PSF_FORMAT_NAMES, canEditTags } from './utils.js';
+import { artPlaceholderEmoji, trapFocus, isUadeAmigaTrack, ATARI_FORMAT_NAMES, PSF_FORMAT_NAMES, canEditTags, MODULE_FORMAT_NAMES, isModuleFamily, surroundLabel } from './utils.js';
 import { mountSignalChain }    from './viz/signalchain.js';
 import { vizGroupEnabled }     from './viz/engine.js';
 
@@ -349,7 +349,8 @@ function _renderScene(track, info) {
   if (!info || !info.found || !info.artist) {
     const msg = info && info.__noartist ? 'No composer name to look up on Demozoo.'
       : info && info.__net             ? 'Couldn’t reach the scene database.'
-      : `No demoscene entry found for “${artist}”.`;
+      : artist                          ? `No demoscene entry found for “${artist}”.`
+      :                                   'No demoscene entry found for this track.';
     sceneBody.innerHTML = baseline() + empty(msg);
     return;
   }
@@ -360,12 +361,16 @@ function _renderScene(track, info) {
   const parts = [];
 
   // ── Artist block ──
-  let ab = `<div class="ti-scene-artist"><div class="ti-scene-name">${esc(a.real_name || artist)}</div>`;
+  // The scene handle: NAME-first carries it in track.artist; TITLE-first leaves
+  // that blank and the resolved handle arrives in a.name.  Fall back to a.name
+  // so the header never renders empty and the handle sub-line isn't a stray “”.
+  const handle = artist || (a && a.name) || '';
+  let ab = `<div class="ti-scene-artist"><div class="ti-scene-name">${esc(a.real_name || handle)}</div>`;
   const sub = [];
-  if (a.real_name && a.real_name.toLowerCase() !== artist.toLowerCase()) sub.push(`“${esc(artist)}”`);
+  if (handle && a.real_name && a.real_name.toLowerCase() !== handle.toLowerCase()) sub.push(`“${esc(handle)}”`);
   if (Array.isArray(a.groups) && a.groups.length) sub.push('Member of ' + esc(a.groups.slice(0, 5).join(', ')));
   if (sub.length) ab += `<div class="ti-scene-sub">${sub.join(' · ')}</div>`;
-  const seen = new Set([artist.toLowerCase(), (a.real_name || '').toLowerCase()]);
+  const seen = new Set([handle.toLowerCase(), (a.real_name || '').toLowerCase()]);
   const aliases = (a.aliases || []).filter(n => n && !seen.has(String(n).toLowerCase()));
   if (aliases.length) ab += `<div class="ti-scene-aka">aka ${esc(aliases.slice(0, 6).join(', '))}</div>`;
   const aChips = [chip(a.url, 'Demozoo')]
@@ -394,6 +399,13 @@ function _renderScene(track, info) {
     (rel.parties || []).slice(0, 3).forEach(pt => {
       if (pt && pt.name) rb += `<div class="ti-scene-compo">▸ Released at ${esc(pt.name)}${pt.year ? ` (${pt.year})` : ''}</div>`;
     });
+    // "Featured in": demos/intros this track scored (from the offline index).
+    const feat = (Array.isArray(rel.featured_in) ? rel.featured_in : [])
+      .filter(f => f && f.title).slice(0, 5);
+    if (feat.length) {
+      const names = feat.map(f => esc(f.title) + (f.year ? ` (${f.year})` : '')).join(', ');
+      rb += `<div class="ti-scene-compo">🎬 Featured in ${names}</div>`;
+    }
     const rChips = [chip(rel.url, 'Demozoo')]
       .concat((rel.links || []).slice(0, 8).map(l => chip(l && l.url, hostOf(l && l.url))))
       .filter(Boolean).join('');
@@ -404,7 +416,7 @@ function _renderScene(track, info) {
 
   // ── Discography ──
   if (disco.length) {
-    let db = `<div class="ti-scene-block"><div class="ti-scene-h">More by ${esc(artist)}</div><ul class="ti-scene-disco">`;
+    let db = `<div class="ti-scene-block"><div class="ti-scene-h">More by ${esc(a.real_name || handle)}</div><ul class="ti-scene-disco">`;
     disco.forEach(p => {
       const su    = safeUrl(p.url);
       const label = esc(p.title);
@@ -451,9 +463,12 @@ async function _loadScene(track) {
   const reqTrackId = track && track.id;
   if (!track) { sceneBody.innerHTML = ''; return; }
   const artist = ((track.artist) || '').trim();
+  const hasArtist = artist && !_isPlaceholderArtist(artist);
+  const title = (track.title || '').trim();
 
-  // No composer name → immediate, cached baseline-only state.
-  if (!artist || _isPlaceholderArtist(artist)) {
+  // Nothing to resolve from (no artist tag AND no song title) → baseline only.
+  // With a title but no artist we fall through to a TITLE-first lookup below.
+  if (!hasArtist && !title) {
     const payload = { found: false, __noartist: true };
     if (reqTrackId) _sceneCache[reqTrackId] = payload;
     _renderScene(track, payload);
@@ -480,9 +495,14 @@ async function _loadScene(track) {
   const _c = (typeof AbortController === 'function') ? new AbortController() : null;
   _sceneAbort = _c;
   try {
-    let q = '/api/artist/scene?name=' + encodeURIComponent(artist) + '&retro=1';
-    if (track.title)  q += '&track='  + encodeURIComponent(track.title);
-    if (track.format) q += '&format=' + encodeURIComponent(track.format);
+    // NAME-first when the module has an artist tag; TITLE-first otherwise (the
+    // server resolves the composer from the song title, narrowed by year/hints).
+    let q = '/api/artist/scene?retro=1';
+    if (hasArtist)          q += '&name='     + encodeURIComponent(artist);
+    if (title)              q += '&track='    + encodeURIComponent(title);
+    if (track.format)       q += '&format='   + encodeURIComponent(track.format);
+    if (track.id)           q += '&track_id=' + encodeURIComponent(track.id);
+    if (track.year != null) q += '&year='     + encodeURIComponent(track.year);
     const r = await fetch(q, _c ? { signal: _c.signal } : undefined);
     if (!r.ok) throw new Error('http ' + r.status);
     const info = await r.json();
@@ -533,56 +553,116 @@ function _renderTagEdit(track) {
     wrap.appendChild(btn);
     return;
   }
-  // Retro/module tracks can't be file-tagged, but their Demozoo-backfilled
-  // release year is worth being able to correct or revert — that's a
-  // STORE-ONLY edit (PUT /year), so it works for remote/archive tracks too.
-  if (_isModuleFamily(track)) {
-    const btn = document.createElement('button');
-    btn.id = 'ti-edit-year';
-    btn.textContent = '✏️ Edit year';
-    btn.style.cssText = 'font-size:12px;padding:4px 10px;opacity:.85';
-    btn.addEventListener('click', () => _showYearForm(track, wrap));
-    wrap.appendChild(btn);
-  }
+  // Reaching here means the file-write editor was declined, so this is a track
+  // the tagwriter can't touch: a module/SID/chip format, an archive member, OR
+  // any file (incl. a plain MP3/FLAC) living on a remote share.  Its metadata is
+  // still worth correcting (a wrong Demozoo year, a mojibake title, a blank
+  // artist), so offer the STORE-ONLY editor (PUT /meta + /year) for ALL of them
+  // — it writes the library, survives rescans, and works regardless of format
+  // or source.  (The panel only ever opens for real library tracks, guarded by
+  // the ``!track.id`` return above, so there's no non-editable pseudo-track to
+  // exclude.)  Previously this was gated on _isModuleFamily, which silently left
+  // remote/archive non-module files (e.g. an MP3 on an SMB mount) with no editor
+  // at all.
+  const btn = document.createElement('button');
+  btn.id = 'ti-edit-info';
+  btn.textContent = '✏️ Edit info';
+  btn.style.cssText = 'font-size:12px;padding:4px 10px;opacity:.85';
+  btn.addEventListener('click', () => _showInfoForm(track, wrap));
+  wrap.appendChild(btn);
 }
 
-function _showYearForm(track, wrap) {
+// Store-only info editor (non-taggable formats).  Mirrors the file-write tag
+// form's fields but saves to the LIBRARY only (PUT /meta); the Year field keeps
+// its Demozoo revert affordance (PUT /year).
+const _META_FIELDS = [
+  ['title', 'Title'], ['artist', 'Artist'], ['album', 'Album'],
+  ['album_artist', 'Album artist'], ['composer', 'Composer'],
+  ['genre', 'Genre'], ['year', 'Year'], ['comment', 'Comment'],
+];
+
+function _showInfoForm(track, wrap) {
   wrap.innerHTML = '';
   const form = document.createElement('div');
-  form.style.cssText = 'display:flex;flex-wrap:wrap;gap:8px;align-items:center;font-size:12.5px';
-  const lab = document.createElement('label');
-  lab.textContent = 'Year'; lab.style.opacity = '.7';
-  const inp = document.createElement('input');
-  inp.type = 'number'; inp.min = '1000'; inp.max = '2100';
-  inp.value = (track.year != null ? track.year : '');
-  inp.style.cssText = 'font-size:12.5px;padding:4px 8px;width:88px';
+  form.style.cssText = 'display:grid;grid-template-columns:92px 1fr;gap:6px 10px;align-items:center;font-size:12.5px';
+  const inputs = {};
+  for (const [key, label] of _META_FIELDS) {
+    const lab = document.createElement('label');
+    lab.textContent = label; lab.style.opacity = '.7';
+    const inp = document.createElement('input');
+    inp.type = key === 'year' ? 'number' : 'text';
+    if (key === 'year') { inp.min = '1000'; inp.max = '2100'; }
+    inp.value = key === 'genre'
+      ? (Array.isArray(track.genre) ? track.genre.join(', ') : (track.genre || ''))
+      : (track[key] ?? '');
+    inp.style.cssText = 'font-size:12.5px;padding:4px 8px;min-width:0';
+    inputs[key] = inp;
+    form.append(lab, inp);
+  }
+  const row = document.createElement('div');
+  row.style.cssText = 'grid-column:1/-1;display:flex;flex-wrap:wrap;gap:8px;margin-top:4px';
   const save = document.createElement('button');
   save.textContent = 'Save'; save.style.cssText = 'font-size:12px;padding:4px 12px';
   const cancel = document.createElement('button');
   cancel.textContent = 'Cancel';
   cancel.style.cssText = 'font-size:12px;padding:4px 12px;opacity:.7';
   cancel.addEventListener('click', () => _renderTagEdit(track));
-  form.append(lab, inp, save, cancel);
-  // A stamped year (Demozoo or a prior user edit) that preserved the original
-  // gets a one-click revert to the file/rip value.
+  row.append(save, cancel);
+  // One-click revert for a stamped year with a preserved original.
   if ((track.year_source === 'demozoo' || track.year_source === 'user')
       && track.year_file != null) {
     const rev = document.createElement('button');
-    rev.textContent = `↺ Revert to file year (${track.year_file})`;
+    rev.textContent = `↺ Revert year to file (${track.year_file})`;
     rev.style.cssText = 'font-size:12px;padding:4px 12px;opacity:.85';
     rev.addEventListener('click', () => _saveYear(track, wrap, { revert: true }));
-    form.appendChild(rev);
+    row.appendChild(rev);
   }
+  form.appendChild(row);
   save.addEventListener('click', () => {
-    const v = inp.value.trim();
-    const n = v === '' ? null : parseInt(v, 10);
-    if (v !== '' && !(n >= 1000 && n <= 2100)) {
-      window.Toast?.error?.('Year must be between 1000 and 2100.'); return;
+    const body = {};
+    for (const [key] of _META_FIELDS) {
+      const raw = inputs[key].value;
+      if (key === 'year') {
+        const v = raw.trim();
+        const n = v === '' ? null : parseInt(v, 10);
+        if (v !== '' && !(n >= 1000 && n <= 2100)) {
+          window.Toast?.error?.('Year must be between 1000 and 2100.'); return;
+        }
+        if (n !== (track.year ?? null)) body.year = n;
+      } else if (key === 'genre') {
+        const cur = Array.isArray(track.genre) ? track.genre.join(', ') : (track.genre || '');
+        if (raw !== cur) body.genre = raw;
+      } else if (raw !== (track[key] ?? '')) {
+        body[key] = raw;
+      }
     }
-    _saveYear(track, wrap, { year: n });
+    if (!Object.keys(body).length) { _renderTagEdit(track); return; }
+    _saveMeta(track, wrap, body);
   });
   wrap.appendChild(form);
-  inp.focus();
+  inputs.title?.focus();
+}
+
+async function _saveMeta(track, wrap, body) {
+  try {
+    const r = await fetch(`/api/tracks/${encodeURIComponent(track.id)}/meta`, {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body), credentials: 'same-origin',
+    });
+    if (!r.ok) {
+      let msg = 'Could not update the info.';
+      try { msg = (await r.json()).detail || msg; } catch (_) {}
+      throw new Error(msg);
+    }
+    const res = await r.json();
+    const applied = res.applied || {};
+    Object.assign(track, applied);
+    if (applied.genre) track.genre = applied.genre;   // server stores a list
+    window.Toast?.ok?.('Info updated.');
+    if (_queue[_idx]?.id === track.id) _render(track);   // guard against nav during save
+  } catch (e) {
+    window.Toast?.error?.(e.message || 'Could not update the info.');
+  }
 }
 
 async function _saveYear(track, wrap, body) {
@@ -780,6 +860,16 @@ function _render(track) {
 
   // ── FILE ──
   _show('ti-format',      track.format);
+  // Surround pill next to the format name — the compact at-a-glance marker that
+  // mirrors the track-list badge (the long-form "5.1 Surround" stays on the
+  // Channels line below).  Hidden for mono/stereo and for module formats.
+  const _surEl = document.getElementById('ti-surround');
+  if (_surEl) {
+    const _surLbl = surroundLabel(track);
+    _surEl.textContent = _surLbl || '';
+    _surEl.title = _surLbl ? `${_surLbl} surround` : '';
+    _surEl.hidden = !_surLbl;
+  }
   _show('ti-bit-depth',   track.bit_depth,   v => `${v}-bit`);
   _show('ti-sample-rate', track.sample_rate, _fmtRate);
   _show('ti-channels',    track.channels,    v => _fmtChannels(v, track));
@@ -866,23 +956,11 @@ function _render(track) {
 }
 
 // ── Module / SID / MIDI extended info ─────────────────────────────────────────
-const _MODULE_FORMATS = new Set([
-    'SID', 'MIDI', 'ProTracker', 'ScreamTracker 3', 'FastTracker 2',
-    'Impulse Tracker', 'MultiTracker', 'OctaMED', 'Composer 669',
-    'DigiBooster Pro', 'AHX', 'HivelyTracker', 'UltraTracker',
-    'ScreamTracker 2', 'Farandole', 'ASYLUM/DMP', 'General DigiMusic',
-    'Imago Orpheus', 'Oktalyzer', 'SoundFX', 'Grave Composer', 'DSIK',
-]);
-
-/** Module-family test: static tracker/SID/MIDI names plus the dynamic-name
- *  scene families (uade Amiga exotica, Atari ST, PSF console rips). */
-function _isModuleFamily(track) {
-  if (!track) return false;
-  return _MODULE_FORMATS.has(track.format)
-      || isUadeAmigaTrack(track)
-      || ATARI_FORMAT_NAMES.has(track.format)
-      || PSF_FORMAT_NAMES.has(track.format);
-}
+// MODULE_FORMAT_NAMES + isModuleFamily moved to utils.js so the track-list
+// surround badge shares ONE definition of "what is a module" with this panel.
+// Local aliases keep every existing reference in this file working unchanged.
+const _MODULE_FORMATS = MODULE_FORMAT_NAMES;
+const _isModuleFamily = isModuleFamily;
 
 /** Demoscene-track test — drives the SCENE-vs-LYRICS tab swap.  It's the
  *  module family MINUS General MIDI: GM/karaoke MIDI isn't demoscene (no

--- a/soniqboom/frontend/js/utils.js
+++ b/soniqboom/frontend/js/utils.js
@@ -206,6 +206,44 @@ export function isRenderOnlyDuration(t) {
 }
 
 /**
+ * Static tracker / SID / MIDI format names.  Kept here (not in trackinfo.js) so
+ * both the info panel and the track list agree on what a "module" is — the
+ * surround badge must never disagree with the panel's channel label.
+ */
+export const MODULE_FORMAT_NAMES = new Set([
+  'SID', 'MIDI', 'ProTracker', 'ScreamTracker 3', 'FastTracker 2',
+  'Impulse Tracker', 'MultiTracker', 'OctaMED', 'Composer 669',
+  'DigiBooster Pro', 'AHX', 'HivelyTracker', 'UltraTracker',
+  'ScreamTracker 2', 'Farandole', 'ASYLUM/DMP', 'General DigiMusic',
+  'Imago Orpheus', 'Oktalyzer', 'SoundFX', 'Grave Composer', 'DSIK',
+]);
+
+/** Module-family test: static tracker/SID/MIDI names plus the dynamic-name
+ *  scene families (uade Amiga exotica, Atari ST, PSF console rips).  These
+ *  formats' ``channels`` are synth VOICES, not a speaker layout. */
+export function isModuleFamily(t) {
+  if (!t) return false;
+  return MODULE_FORMAT_NAMES.has(t.format)
+      || isUadeAmigaTrack(t)
+      || ATARI_FORMAT_NAMES.has(t.format)
+      || PSF_FORMAT_NAMES.has(t.format);
+}
+
+/**
+ * Speaker-layout tag for a REAL multichannel PCM track ("5.1", "7.1", …), or
+ * null for mono/stereo AND for every module/chip format (whose ``channels`` are
+ * synth voices — an 8-voice .s3m is NOT 7.1).  Single source of truth for the
+ * surround badge in both the track list and the info panel; mirrors the panel's
+ * long-form ``_fmtChannels`` label (6→5.1, 8→7.1).
+ */
+export function surroundLabel(t) {
+  if (!t || isModuleFamily(t)) return null;
+  const n = t.channels;
+  if (!n || n <= 2) return null;
+  return { 3: '2.1', 4: '4.0', 6: '5.1', 7: '6.1', 8: '7.1' }[n] || `${n}ch`;
+}
+
+/**
  * Containers whose tags core/tagwriter.py (mutagen, easy interface) can
  * actually WRITE: ID3/EasyMP3, EasyMP4, VorbisComment, APEv2.  An
  * ALLOWLIST by extension, not a format-name denylist, because (a) the

--- a/soniqboom/frontend/sw.js
+++ b/soniqboom/frontend/sw.js
@@ -618,7 +618,123 @@
 // the ~50MB warm upload and skip if the server self-cached during the listen.
 // (Backend A1/A2 — admin-gate + disk-spool + upload semaphore — also landed;
 // server restarted.)  app.js?v→138.
-const SHELL_VERSION = 'v169';   // v169: P1/P2 fixes — year provenance (persist across
+const SHELL_VERSION = 'v194';   // v194: Demozoo "Reset enrichment" admin button + name-first ambig/paren resolution
+                                // (run-probe) so a present-but-broken renderer
+                                // (dyld/loader failure) shows red instead of a
+                                // false ✓; needs the backend admin.py restart too.
+                                // v190: surround badge polish — Type column left-
+                                // aligned + widened so FLAC/5.1 line up across rows;
+                                // dropped the ⊙ glyph (text-only pill).
+                                // v189: surround badge (5.1 / 7.1 / …) next to the
+                                // format in the list + info panel; shared
+                                // surroundLabel/isModuleFamily in utils.js so a
+                                // module's synth "voices" never read as speakers.
+                                // v188: search box ships `readonly`, dropped on first
+                                // keystroke / right-click — stops Edge's password
+                                // manager offering the saved login on the search
+                                // field (Edge ignores type=search + autocomplete=off).
+                                // v187: cross-scope QA round 7 — refreshSmartOnPlay
+                                // gates on the nav-token view identity, not crumb
+                                // text, so a play-record can't clobber a folder /
+                                // album that merely shares the "Most Played" crumb.
+                                // v186: cross-scope QA round 6 — the drill / "Go to
+                                // artist/album" pivots now clear _viewIsAllTracks at
+                                // entry (via restoreFullHeader), so a pivot FROM All
+                                // Tracks isn't yanked back by a scan; + showFolder
+                                // flag-consistency + playlist commit-after-recheck.
+                                // v185: cross-scope QA round 5 — stale-view-flag
+                                // family: showAlbums/setGroupHeader now clears the
+                                // folder path, showSmart/showDuplicates/search clear
+                                // _viewIsAllTracks at entry (so a mid-fetch scan
+                                // refresh can't clobber them); + stations country
+                                // bucket-race + playlist open-race guards.
+                                // v184: cross-scope QA round 4 — CLOSE the render
+                                // race across ALL async view paths: guard showSmart
+                                // /showDuplicates, make showGalaxy bump the token,
+                                // fix the folder QUIET refresh to capture-not-optout
+                                // (so it bails on nav-away), and guard search.js
+                                // query() via exported beginView/viewStillCurrent.
+                                // v183: cross-scope QA round 3 — extend the render-
+                                // race guard to the track DRILLS + folders (a slow
+                                // drill no longer paints under a newer facet's
+                                // header) and clear _viewIsAllTracks in
+                                // setGroupHeader so a background refresh can't
+                                // cancel an in-flight facet nav.
+                                // v182: cross-scope QA round 2 — group-view render
+                                // race guard (_browseNavGen: a slow first fetch no
+                                // longer paints under a faster second view's header)
+                                // + untagged-drill ([No Artist]/[No Album Artist])
+                                // now discloses its 5k-fetch cap like other drills.
+                                // v181: cross-scope QA — Artists/Album-Artists
+                                // count is a TRACK count (was mislabeled "Albums"
+                                // → "Tracks"); group-row counts pluralise ("1
+                                // Album"); an artist/album-artist with no album
+                                // tag falls back to a flat track list instead of
+                                // an empty album view.
+                                // v177: adversarial-review fixes — the persisted
+                                // sort arrow is no longer painted on views that
+                                // render in their own order (search/drills/smart/
+                                // duplicates/format): restoreFullHeader restores
+                                // sort STATE only, and ONLY showAll paints the
+                                // arrow (via _paintSortIndicator) since it alone
+                                // re-applies the sort.  Folder views rebuild a
+                                // clean sortable header (_rebuildTrackHeader) so
+                                // they don't inherit a stale arrow/colspan.  Boot
+                                // view-restore falls back to All Tracks if the
+                                // restored view's fetch rejects (app.js?v=152 +
+                                // library.js). v176: final-QA-round fixes — (a) sorting the
+                                // All-Tracks view now KEEPS isInAllTracksView()
+                                // true (was demoted → lost post-scan refresh);
+                                // (b) sorting a large FOLDER view bails with a
+                                // toast instead of refetching the whole library;
+                                // (c) restoreFullHeader() clears the folder path
+                                // so smart/duplicates/pivot/search views can't be
+                                // yanked back into a stale folder by a scan; plus
+                                // showGalaxy clears the All-Tracks flag
+                                // (app.js?v=151 + library.js + search.js).
+                                // v175: QA-round fixes — post-scan main-panel
+                                // refresh now goes through ONE shared helper
+                                // (_refreshMainAfterScan) gated on a precise
+                                // Library.isInAllTracksView() flag, used by the
+                                // WS complete + embedding handlers AND the HTTP
+                                // stuck-badge watchdog — so a scan/embedding event
+                                // (or the watchdog fallback) never yanks a group /
+                                // SEARCH / format-filter view back to All Tracks.
+                                // Search renders via showSearchResults() (full
+                                // sortable header, no stale group filter). Frontend
+                                // search operators trimmed to the 6 the backend
+                                // implements (title:/composer:/albumartist: now show
+                                // 'Unknown field'). Small-library All-Tracks applies
+                                // the persisted sort; a persisted non-windowed sort
+                                // key no longer paints a false arrow on the windowed
+                                // view (app.js?v=150 + library.js + search.js).
+                                // v174: visual-QA fixes — Scene-groups reload no
+                                // longer shows a track list.  Root cause: a WS
+                                // scan-complete/embedding event fires seconds after
+                                // a server restart and its handler called showAll(),
+                                // overwriting the restored view — now gated on the
+                                // user actually being on All Tracks (also stops any
+                                // scan-complete yanking you out of a group/search
+                                // view mid-session).  Plus: boot restore skips the
+                                // default showAll(); windowed-store repaint guarded
+                                // on still-active view; non-windowed sort columns
+                                // (track#/path) no longer paint a phantom sort arrow;
+                                // group-view switch hides the stale filter bar
+                                // synchronously (app.js?v=149 + library.js).
+                                // v171: QA-round-2 fixes — carry hand-edited artist
+                                // BEFORE the scene_group/year identity check (edit no
+                                // longer drops enrichment on rescan); ALL drill-downs
+                                // (genre/year/scene-group/album/artist) 500→2000 with an
+                                // honest "showing first N of M" crumb cue when capped
+                                // (count-vs-list parity); store editor now covers
+                                // remote/archive non-module files; post-scan facet reveal
+                                // polls a backoff ladder, not fixed timers
+                                // (app.js?v=142 + library.js/trackinfo.js under its graph).
+                                // v170: enhancements — post-scan Demozoo auto-apply,
+                                // Scene-groups browse facet, store-only info editor,
+                                // 'featured in demo', detach-and-finish blocking renders
+                                // (app.js?v=141 + library.js/trackinfo.js under its graph).
+                                // v169: P1/P2 fixes — year provenance (persist across
                                 // rescan + store-only year editor, app.js?v=140), SID render
                                 // pool hardening (blocking cap, seek-supersede, stuck-slot).   // v168 (1.8.0): SCENE tab (trackinfo.js/index.html/app.css?v=91), SID VU
                                 // overhaul (app.js?v=139 — source-decoupled sidecars, longer poll ladder,

--- a/soniqboom/main.py
+++ b/soniqboom/main.py
@@ -729,6 +729,11 @@ def _reap_orphaned_forkservers() -> int:
     return reaped
 
 
+# Strong refs to detached fire-and-forget startup tasks — without a live reference
+# asyncio may garbage-collect a bare create_task() mid-flight (CPython docs).
+_BG_TASKS: "set" = set()
+
+
 @app.on_event("startup")
 async def startup():
     global _aof_writer, _merger_proc
@@ -781,6 +786,40 @@ async def startup():
         asyncio.create_task(reap_orphan_zip_extracts(), name="reap_zip_extracts")
     except Exception:
         log.debug("zip-extract reap scheduling failed", exc_info=True)
+
+    # Full renderer health check a few seconds after boot: exec-probe every
+    # plain-binary renderer and log a one-line summary, WARNing on any that are
+    # present-but-broken (e.g. a from-source zxtune123/sidplayfp orphaned by a
+    # Homebrew library upgrade — dyld "Symbol not found"/"Library not loaded" —
+    # which passes a file-exists check but 501s at play time).  Surfaces it once,
+    # loudly, so the operator learns before a listener hits a dead format.
+    # Fire-and-forget with a strong ref (asyncio may GC a bare task); the short
+    # delay keeps the exec probes off the boot-critical path.
+    async def _probe_renderer_health():
+        try:
+            await asyncio.sleep(5)
+            from soniqboom.api.admin import validate_renderers
+            status = await validate_renderers()
+            broken = {n: v for n, v in status.items() if v["status"] == "broken"}
+            missing = sorted(n for n, v in status.items() if v["status"] == "missing")
+            ok = sum(1 for v in status.values() if v["status"] == "ok")
+            log.info("renderer health: %d ok, %d broken, %d missing (of %d binary renderers)",
+                     ok, len(broken), len(missing), len(status))
+            for name, v in broken.items():
+                log.warning(
+                    "renderer %s is installed at %s but FAILS TO LOAD — a shared "
+                    "library was upgraded out from under it; reinstall or rebuild it "
+                    "to fix (its formats are disabled until then).", name, v["path"])
+            if missing:
+                log.info("renderers not installed (their formats are unavailable): %s",
+                         ", ".join(missing))
+        except Exception:
+            log.debug("renderer health probe failed", exc_info=True)
+    try:
+        _t = asyncio.create_task(_probe_renderer_health(), name="renderer_health_probe")
+        _BG_TASKS.add(_t); _t.add_done_callback(_BG_TASKS.discard)
+    except Exception:
+        log.debug("renderer health probe scheduling failed", exc_info=True)
 
     # Pre-warm the per-scan-root sorted cache for every LOCAL scan root.
     # Pays the one-time O(bucket-size) iterate + TrackMeta shape cost
@@ -1552,6 +1591,13 @@ async def shutdown():
             await asyncio.wait_for(_cast_reaper_task, timeout=1.0)
         except (asyncio.TimeoutError, asyncio.CancelledError):
             pass
+
+    # Cancel any detached fire-and-forget startup tasks still pending (e.g. the
+    # renderer-health probe within its 5 s delay) so shutdown doesn't log a stray
+    # "Task was destroyed but it is pending".
+    for _t in list(_BG_TASKS):
+        if not _t.done():
+            _t.cancel()
 
     # Stop the deadlock watchdog so its asyncio.sleep doesn't keep the
     # event loop alive past the shutdown budget.  Idempotent.

--- a/soniqboom/models/track.py
+++ b/soniqboom/models/track.py
@@ -98,6 +98,13 @@ class TrackMeta(BaseModel):
     # refresh it normally.
     year_source: str | None = None
     year_file: int | None = None
+    # Field names the user hand-edited in the LIBRARY only (store-only editor
+    # for formats that can't be tag-written — modules, SID, chip, archive
+    # members).  Those fields are re-read from the file on a rescan and would
+    # revert, so they're carried forward like the year (see
+    # store._carry_enrichment).  A file-write tag edit needs no entry here — the
+    # file itself holds the value.
+    user_edited: list[str] | None = None
 
     # Art
     cover_art: str | None = None  # data-URI thumbnail

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 S.F. Cyris
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# ── SoniqBoom · Start ────────────────────────────────────────────────────────
+# Thin alias for run.sh (the canonical start script), so `bash startup.sh` and
+# `bash run.sh` are equivalent.  All arguments (e.g. --port 9000) are forwarded.
+# Stop with:  bash shutdown.sh     Restart with:  bash restart.sh
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$SCRIPT_DIR/run.sh" "$@"

--- a/tests/test_autoapply.py
+++ b/tests/test_autoapply.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2026 S.F. Cyris
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""The post-scan Demozoo auto-apply must COALESCE, never drop a scan's delta:
+a scan that drains while a prior apply is running (or right after one) has to be
+folded in on a follow-up pass."""
+import asyncio
+
+import pytest
+
+from soniqboom.core import scanner, demozoo
+
+
+async def _drain_runner():
+    for _ in range(200):
+        await asyncio.sleep(0.01)
+        if not scanner._scene_autoapply_running:
+            return
+
+
+@pytest.mark.asyncio
+async def test_autoapply_coalesces_delta_during_running_apply(monkeypatch):
+    monkeypatch.setattr(demozoo, "has_index", lambda: True)
+    monkeypatch.setattr(demozoo, "auto_apply_enabled", lambda: True)
+    monkeypatch.setattr(scanner, "_SCENE_AUTOAPPLY_SETTLE_S", 0)
+    scanner._scene_autoapply_pending = False
+    scanner._scene_autoapply_running = False
+
+    calls = []
+    first_started = asyncio.Event()
+
+    async def fake_apply():
+        calls.append(1)
+        if len(calls) == 1:
+            first_started.set()
+            await asyncio.sleep(0.2)          # apply A is running…
+        return {"updated": 0}
+
+    monkeypatch.setattr(demozoo, "apply_to_library", fake_apply)
+
+    scanner._spawn_scene_autoapply()          # scan A drains
+    await asyncio.wait_for(first_started.wait(), timeout=2)
+    scanner._spawn_scene_autoapply()          # scan B drains WHILE apply A runs
+    await _drain_runner()
+    assert len(calls) >= 2, "B's enrichment delta was dropped"
+
+
+@pytest.mark.asyncio
+async def test_autoapply_retries_when_manual_apply_holds_the_lock(monkeypatch):
+    monkeypatch.setattr(demozoo, "has_index", lambda: True)
+    monkeypatch.setattr(demozoo, "auto_apply_enabled", lambda: True)
+    monkeypatch.setattr(scanner, "_SCENE_AUTOAPPLY_SETTLE_S", 0)
+    scanner._scene_autoapply_pending = False
+    scanner._scene_autoapply_running = False
+
+    calls = []
+
+    async def fake_apply():
+        calls.append(1)
+        # first call: a manual Admin apply holds the lock
+        if len(calls) == 1:
+            return {"error": "apply already running"}
+        return {"updated": 3}
+
+    monkeypatch.setattr(demozoo, "apply_to_library", fake_apply)
+    scanner._spawn_scene_autoapply()
+    await _drain_runner()
+    assert len(calls) >= 2, "lock-contended delta was dropped instead of retried"
+
+
+@pytest.mark.asyncio
+async def test_autoapply_noop_without_index(monkeypatch):
+    monkeypatch.setattr(demozoo, "has_index", lambda: False)
+    scanner._scene_autoapply_pending = False
+    scanner._scene_autoapply_running = False
+    called = []
+    monkeypatch.setattr(demozoo, "apply_to_library",
+                        lambda: called.append(1) or {"updated": 0})
+    scanner._spawn_scene_autoapply()
+    await asyncio.sleep(0.05)
+    assert not called and not scanner._scene_autoapply_running
+
+
+@pytest.mark.asyncio
+async def test_autoapply_stops_when_toggled_off_mid_coalesce(monkeypatch):
+    """F1 regression: a Reset flipping the toggle OFF while the coalescing runner
+    is looping must STOP it, not re-enrich a just-reset library.  The guard was
+    only in _spawn; the _run loop re-applied without re-checking."""
+    monkeypatch.setattr(demozoo, "has_index", lambda: True)
+    monkeypatch.setattr(scanner, "_SCENE_AUTOAPPLY_SETTLE_S", 0)
+    enabled = {"v": True}
+    monkeypatch.setattr(demozoo, "auto_apply_enabled", lambda: enabled["v"])
+    scanner._scene_autoapply_pending = False
+    scanner._scene_autoapply_running = False
+    calls = []
+
+    async def fake_apply():
+        calls.append(1)
+        enabled["v"] = False                  # a Reset turns the toggle OFF…
+        scanner._scene_autoapply_pending = True  # …and a scan delta arrives after
+        return {"updated": 0}
+
+    monkeypatch.setattr(demozoo, "apply_to_library", fake_apply)
+    scanner._spawn_scene_autoapply()
+    await _drain_runner()
+    assert calls == [1], "runner re-applied after the toggle went OFF"
+
+
+@pytest.mark.asyncio
+async def test_reset_waits_out_inflight_apply(monkeypatch):
+    """F2 regression: Reset must not silently no-op while an apply holds the
+    lock — it waits (bounded) for the lock, then runs."""
+    monkeypatch.setattr(demozoo, "reset_enrichment", lambda: (0, []))
+    demozoo._status["applying"] = True
+
+    async def _release():
+        await asyncio.sleep(0.05)
+        demozoo._status["applying"] = False
+
+    asyncio.ensure_future(_release())
+    res = await demozoo.reset_to_file_state()
+    assert res.get("error") != "apply already running"   # it waited, not a no-op
+    assert res.get("cleared") == 0
+    assert demozoo._status["applying"] is False           # released the lock

--- a/tests/test_demozoo_scene.py
+++ b/tests/test_demozoo_scene.py
@@ -178,13 +178,15 @@ def _write_dump(tmp_path, *, with_supertype: bool):
         prod_rows = ("5000\tZap Tune Deluxe\tmusic\t1992-06-01\n"
                      "6000\tZap Tune Deluxe Party Invitation\tproduction\t1993-01-01\n"
                      "7000\tUndated Groove Tune\tmusic\t\\N\n"
-                     "8000\tOcean Loader 2\tmusic\t1987-03-01")
+                     "8000\tOcean Loader 2\tmusic\t1987-03-01\n"
+                     "9000\tSecond Reality\tproduction\t1993-08-01")   # a DEMO using 8000
     else:
         prod_cols = "id, title"
         prod_rows = ("5000\tZap Tune Deluxe\n"
                      "6000\tZap Tune Deluxe Party Invitation\n"
                      "7000\tUndated Groove Tune\n"
-                     "8000\tOcean Loader 2")
+                     "8000\tOcean Loader 2\n"
+                     "9000\tSecond Reality")
     dump = (
         "COPY public.demoscene_releaser (id, name, first_name, surname, is_group) FROM stdin;\n"
         "100\tzap\tAnn\tSmith\tf\n200\tzap\tBob\tJones\tf\n"
@@ -197,6 +199,9 @@ def _write_dump(tmp_path, *, with_supertype: bool):
         f"COPY public.productions_production ({prod_cols}) FROM stdin;\n{prod_rows}\n\\.\n"
         "COPY public.productions_production_author_nicks (id, production_id, nick_id) FROM stdin;\n"
         "1\t5000\t1000\n2\t6000\t2000\n3\t7000\t1000\n4\t8000\t3000\n\\.\n"
+        # demo 9000 uses music 8000 (Ocean Loader 2) as its soundtrack
+        "COPY public.productions_soundtracklink (id, production_id, soundtrack_id) FROM stdin;\n"
+        "1\t9000\t8000\n\\.\n"
     )
     import gzip as _gz
     p = tmp_path / "dump.sql.gz"
@@ -209,7 +214,7 @@ def test_parse_dump_shared_handle_music_only(tmp_path):
     """With supertypes present, the shared handle 'zap' only carries the
     MUSICIAN's (releaser 100) music production as disambiguation evidence — the
     coder namesake's colliding DEMO title is excluded."""
-    unique, ambig, _ = demozoo._parse_dump(_write_dump(tmp_path, with_supertype=True))
+    unique, ambig, _, _ = demozoo._parse_dump(_write_dump(tmp_path, with_supertype=True))
     rids = {row[1] for row in ambig if row[0] == "zap"}
     assert rids == {100}                       # coder (200) contributes no music
     assert not any("party" in row[4] for row in ambig)   # demo tokens absent
@@ -219,7 +224,7 @@ def test_parse_dump_no_supertype_column_degrades(tmp_path):
     """A dump WITHOUT a supertype column keeps the previous all-productions
     behaviour for disambiguation, and yields ONLY veto rows (year None) for the
     year gate — no dates ⇒ no year is ever stamped, but nothing crashes."""
-    unique, ambig, prod_years = demozoo._parse_dump(_write_dump(tmp_path, with_supertype=False))
+    unique, ambig, prod_years, _ = demozoo._parse_dump(_write_dump(tmp_path, with_supertype=False))
     rids = {row[1] for row in ambig if row[0] == "zap"}
     assert rids == {100, 200}                  # no supertype ⇒ no filtering
     assert prod_years and all(y is None for _, _, y in prod_years)
@@ -228,12 +233,19 @@ def test_parse_dump_no_supertype_column_degrades(tmp_path):
 def test_parse_dump_prod_years_shapes(tmp_path):
     """prod_years: MUSIC only, digit tokens kept, undated rows preserved as
     year-None vetoes, the demo excluded."""
-    _, _, prod_years = demozoo._parse_dump(_write_dump(tmp_path, with_supertype=True))
+    _, _, prod_years, _ = demozoo._parse_dump(_write_dump(tmp_path, with_supertype=True))
     assert sorted(prod_years) == [
         ("100", "deluxe tune zap", 1992),
         ("100", "groove tune undated", None),   # undated ⇒ veto row
         ("300", "2 loader ocean", 1987),        # '2' survives _year_toks
     ]
+
+
+def test_parse_dump_soundtrack_links(tmp_path):
+    """The 4th return maps a MUSIC production → the demo(s) that used it,
+    resolved to the demo's title + year (inverting the demo→music link)."""
+    _, _, _, prod_soundtrack = demozoo._parse_dump(_write_dump(tmp_path, with_supertype=True))
+    assert prod_soundtrack == [(8000, "Second Reality", 1993)]
 
 
 # ── _production_year: exact-identity + veto + consensus gate ─────────────────
@@ -289,6 +301,15 @@ def _run_collect(monkeypatch, tracks):
     import soniqboom.core.store as store_mod
     monkeypatch.setattr(store_mod, "get_store", lambda: _FakeStore(tracks))
     return demozoo.collect_updates()
+
+
+def test_production_soundtracks_offline(tmp_path, monkeypatch):
+    """After a build, the 'featured in' lookup resolves a music production id to
+    the demo(s) that used it; an unknown id (or a pre-soundtrack index) → []."""
+    _built_index(tmp_path, monkeypatch)
+    assert demozoo._production_soundtracks(8000) == [{"title": "Second Reality", "year": 1993}]
+    assert demozoo._production_soundtracks(99999) == []
+    assert demozoo._production_soundtracks("not-an-int") == []
 
 
 def test_collect_updates_stamps_and_preserves_original(tmp_path, monkeypatch):
@@ -358,3 +379,253 @@ def test_collect_updates_undated_veto_blocks_stamp(tmp_path, monkeypatch):
     ])
     assert matched == 1                         # resolves via ambig title match
     assert batch == []                          # but no year is stamped
+
+
+# ── composer credit gate (the wrong-write cardinal sin) ──────────────────────
+# A no-artist scene module's ``composer`` is persisted PERMANENTLY (fill-only,
+# no provenance/revert), so a "by X" credit may name the composer ONLY when it
+# is a bare "By X" signature or a MUSIC-qualified credit.  These lock the gate
+# against the two holes that shipped twice: a non-music word DETACHED from "by"
+# by punctuation ("graphics: by X"), and a non-music word simply OMITTED from a
+# blacklist ("gr by X", "sfx by X").  The gate is a whitelist — any unrecognised
+# word before "by" is refused — so both classes stay closed.
+@pytest.mark.parametrize("sample", [
+    # non-music word adjacent to "by"
+    "gfx by felisuco", "graphics by felisuco", "logo by felisuco",
+    "ripped by felisuco", "cracked by felisuco", "code by felisuco",
+    "coded by felisuco", "design by felisuco", "greets by felisuco",
+    # non-music word DETACHED by punctuation (the CRITICAL leak)
+    "graphics: by felisuco", "graphics - by felisuco", "graphics/ by felisuco",
+    "graphics. by felisuco", "graphics, by felisuco", "graphics| by felisuco",
+    "logo/by felisuco", "pixels. by felisuco",
+    # non-music word OMITTED from any blacklist (the HIGH leak)
+    "gr by felisuco", "grfx by felisuco", "grafik by felisuco",
+    "sfx by felisuco", "fx by felisuco", "vocals by felisuco",
+    "samples by felisuco", "sampled by felisuco", "words by felisuco",
+    "lyrics by felisuco", "text by felisuco", "voice by felisuco",
+    "presented by felisuco", "made by felisuco", "arranged by felisuco",
+    "remix by felisuco", "trained by felisuco",
+])
+def test_music_credits_rejects_non_music(sample):
+    """Not a composer credit → nothing is persistable."""
+    assert demozoo._music_credits([sample]) == []
+
+
+@pytest.mark.parametrize("sample,handle", [
+    ("by felisuco", "felisuco"),
+    ("By felisuco", "felisuco"),
+    ("music by felisuco", "felisuco"),
+    ("composed by felisuco", "felisuco"),
+    ("tune by felisuco", "felisuco"),
+    ("song by felisuco", "felisuco"),
+    ("melody by felisuco", "felisuco"),
+    ("great music by felisuco", "felisuco"),
+    ("by 4-mat", "4-mat"),                       # hyphenated handle kept intact
+    ("by U4ia", "U4ia"),
+])
+def test_music_credits_accepts_genuine(sample, handle):
+    """Bare or music-qualified "by X" → the composer handle, original case."""
+    assert demozoo._music_credits([sample]) == [handle]
+
+
+@pytest.mark.parametrize("sample,handle", [
+    ("By Purple Motion -93", "Purple Motion"),   # space-dash year tag trimmed
+    ("By Purple Motion 1993", "Purple Motion"),  # bare year tag trimmed
+    ("By Purple Motion of the Future Crew", "Purple Motion"),  # group tail
+    ("music by Jugi - Complex", "Jugi"),         # " - group" tail
+    ("by Jester & Yolk", "Jester"),              # collaborator tail
+])
+def test_music_credits_trims_tail(sample, handle):
+    assert demozoo._music_credits([sample]) == [handle]
+
+
+@pytest.mark.parametrize("sample", [
+    "ripped by pirate / music by felisuco",      # first credit is a rip, not music
+    "gfx by artist, music by felisuco",
+    "cracked by group | tune by felisuco",
+])
+def test_music_credits_multi_credit_finds_the_music(sample):
+    """A non-music credit FOLLOWED by a real music credit must not swallow it."""
+    assert demozoo._music_credits([sample]) == ["felisuco"]
+
+
+def test_author_hints_persist_gate():
+    """``author_hints_from_track`` exposes a music credit for PERSISTENCE only
+    when it is genuine; a graphics/rip credit yields no persistable credit."""
+    _, credits = demozoo.author_hints_from_track(
+        title="Fast Music", instruments=["gfx by felisuco"])
+    assert credits == {}                         # nothing to write
+    _, credits = demozoo.author_hints_from_track(
+        title="Fast Music", instruments=["music by Purple Motion"])
+    assert credits == {"purple motion": "Purple Motion"}  # normalised→original
+
+
+# ── cross-slot credit split (a role word one sample slot up from "by X") ──────
+# Sample lists spell one credit fragment per slot, so a "gfx"/"ripped"/… credit
+# can land in the slot BEFORE the "by X" — which, scanned per-slot, would read
+# as a bare composer signature.  A KNOWN role word in the previous slot vetoes
+# it; an unrelated previous word (a date, a bpm, a greeting — the overwhelming
+# real-library case) must NOT, or 800+ genuine signatures would be lost.
+@pytest.mark.parametrize("instruments", [
+    ["gfx", "by kapteinar"],
+    ["graphics", "by kapteinar"],
+    ["ripped and converted", "by thexder"],
+    ["#### ripped ####", "by mr.young"],
+    ["Bad Samples", "by Luv Kohli"],
+    ["in full stereo sound", "by www.elysis.de"],
+    ["graphics", "by kapteinar", "music", "by someone"],  # role split, real music elsewhere
+])
+def test_music_credits_cross_slot_role_split_rejected(instruments):
+    """A non-music role in the previous slot must not leak a bare "by X"."""
+    assert "kapteinar" not in [c.lower() for c in demozoo._music_credits(instruments)]
+    if instruments == ["gfx", "by kapteinar"]:
+        assert demozoo._music_credits(instruments) == []
+
+
+@pytest.mark.parametrize("instruments,handle", [
+    (["Chip Land", "By Zeus"], "Zeus"),
+    (["twenty seconds", "by pkk"], "pkk"),
+    (["200bpm", "By Midnight Flip '97"], "Midnight Flip"),  # + apostrophe-year trim
+    (["Composed Nov. 12 1992", "by SWAMPFOX"], "SWAMPFOX"),
+    (["greetings to everyone", "music", "by kapteinar"], "kapteinar"),  # prev slot = music word
+])
+def test_music_credits_cross_slot_signature_accepted(instruments, handle):
+    """A bare "By <scener>" trailing UNRELATED text is a real signature."""
+    assert demozoo._music_credits(instruments) == [handle]
+
+
+@pytest.mark.parametrize("sample,handle", [
+    ("music by Catch 22", "Catch 22"),           # 22 is not a plausible year
+    ("music by Area 51", "Area 51"),
+    ("by 2 Unlimited", "2 Unlimited"),
+])
+def test_music_credits_preserves_numeric_handle(sample, handle):
+    """The year-tail trim must not eat a digit-bearing handle (would collide
+    with a different, real scener)."""
+    assert demozoo._music_credits([sample]) == [handle]
+
+
+# ── cross-slot role word that is NOT the previous slot's LAST word ────────────
+# The veto scans the WHOLE previous slot, not just its trailing word — a role
+# verb is routinely non-terminal ("cracked together", "converted in 0.30 min").
+# These are confirmed real-library wrong-writes (a cracker/converter written as
+# the composer) that a last-word-only check let through.
+@pytest.mark.parametrize("instruments", [
+    ["cracked together", "by sinatra"],
+    ["samples & jingles", "by loxley"],
+    ["ORIGINAL BY JENS", "CONVERTED IN 0.30 MIN", "BY TYAN"],
+    ["Converted with Pro-Wizard", "by Gryzor"],
+])
+def test_music_credits_cross_slot_nonterminal_role_rejected(instruments):
+    assert demozoo._music_credits(instruments) == []
+
+
+# ── "tracked" is a MUSIC verb (sequenced in a tracker), not a rip role ────────
+@pytest.mark.parametrize("sample,handle", [
+    ("tracked by necros", "necros"),
+    ("written and tracked by necros", "necros"),
+    ("Composed & Tracked by SMASH", "SMASH"),
+    ("tracked 2001-01-08 by eSeMGy", "eSeMGy"),
+])
+def test_music_credits_tracked_is_music(sample, handle):
+    assert demozoo._music_credits([sample]) == [handle]
+
+
+def test_music_credits_cross_slot_music_word_suppresses_veto():
+    """A previous slot that pairs a role with a MUSIC word is not a veto —
+    "music & gfx / by X" means X did the music (too)."""
+    assert demozoo._music_credits(["music & gfx", "by artist"]) == ["artist"]
+
+
+def test_music_credits_non_str_slot_is_safe():
+    """A non-str slot (int/None/dict) must not raise — it would abort the whole
+    batch apply.  Guarded to empty; a valid credit alongside still resolves."""
+    assert demozoo._music_credits([123, "by artist", None, {"x": 1}]) == ["artist"]
+
+
+# ── lookup_scener: sole-producer shared handle resolves without a title ───────
+# A handle lands in ambig_prod when >1 releaser carries it, but only the ones
+# who RELEASED something appear — so a "shared" handle often has a single real
+# candidate.  It must resolve outright (the productionless namesakes can't be a
+# music track's author); requiring a title match stranded famous handles like
+# "Purple Motion" (→ Jonne Valtonen) whose title was single-token.  In the test
+# index, "zap" is shared by 100 (musician) + 200 (coder), but only 100's MUSIC
+# production reaches ambig_prod — so "zap" resolves to 100 with no title.
+def test_lookup_scener_sole_producer_resolves_without_title(tmp_path, monkeypatch):
+    _built_index(tmp_path, monkeypatch)
+    card = demozoo.lookup_scener("zap")            # NO title
+    assert card and card["releaser_id"] == 100 and card["real_name"] == "Ann Smith"
+    # and still resolves the same with a title present
+    card2 = demozoo.lookup_scener("zap", "Zap Tune Deluxe")
+    assert card2 and card2["releaser_id"] == 100
+    # a handle no one released is still unknown
+    assert demozoo.lookup_scener("nobody-here") is None
+
+
+def test_lookup_scener_real_name_paren_handle_prefers_primary(tmp_path, monkeypatch):
+    """"Real Name (Handle)" whose parenthetical collides with a DIFFERENT scener
+    must resolve to the authoritative pre-paren name, not refuse.  In the test
+    index "alpha" (400), "beta" (500), "moby" (300) are distinct unique sceners;
+    "alpha (moby)" pools both → disagree → old code refused.  Now the
+    paren-stripped primary wins (regardless of which side the collision is on)."""
+    _built_index(tmp_path, monkeypatch)
+    assert demozoo.lookup_scener("alpha (moby)", "x")["releaser_id"] == 400
+    assert demozoo.lookup_scener("beta (moby)", "x")["releaser_id"] == 500
+
+
+# ── reset_enrichment: withdraw enrichment, preserve file tags + user edits ────
+def test_reset_enrichment_withdraws_only_enrichment(monkeypatch):
+    """Clears the Demozoo year backfill (→ year_file), scene_group, and the
+    no-artist-module composer; leaves user hand-edits, user years, real
+    file-tag composers (non-retro), and already-clean tracks untouched."""
+    tracks = [
+        {"id": "1", "format": "ProTracker", "artist": "", "composer": "4-mat",
+         "scene_group": "Anarchy • Cosine", "year": 1991,
+         "year_source": "demozoo", "year_file": 2007},
+        {"id": "2", "format": "ScreamTracker 3", "artist": "Purple Motion",
+         "composer": "", "scene_group": "Future Crew", "year": 1993,
+         "year_source": "demozoo", "year_file": None},
+        {"id": "3", "format": "ProTracker", "artist": "", "composer": "My Fix",
+         "scene_group": "My Crew", "user_edited": ["composer", "scene_group"]},
+        {"id": "4", "format": "ProTracker", "artist": "", "year": 1988,
+         "year_source": "user", "year_file": 1990},
+        {"id": "5", "format": "MP3", "artist": "", "composer": "J.S. Bach"},
+        {"id": "6", "format": "ProTracker", "artist": "", "composer": "",
+         "scene_group": ""},
+    ]
+    import soniqboom.core.store as store_mod
+    monkeypatch.setattr(store_mod, "get_store", lambda: _FakeStore(tracks))
+    count, batch = demozoo.reset_enrichment()
+    bd = dict(batch)
+    assert count == 2
+    assert bd["1"] == {"year": 2007, "year_source": None, "year_file": None,
+                       "scene_group": None, "composer": None}
+    assert bd["2"] == {"year": None, "year_source": None, "year_file": None,
+                       "scene_group": None}          # empty composer not touched
+    for untouched in ("3", "4", "5", "6"):           # user edits / user year /
+        assert untouched not in bd                   # file tag / already clean
+    # idempotent: applying the batch (no scene_group/composer/demozoo-year left)
+    # yields nothing on a second pass
+    cleaned = []
+    for t in tracks:
+        t = dict(t)
+        t.update(bd.get(t["id"], {}))
+        cleaned.append(t)
+    monkeypatch.setattr(store_mod, "get_store", lambda: _FakeStore(cleaned))
+    assert demozoo.reset_enrichment()[0] == 0
+
+
+def test_auto_apply_toggle_roundtrip(monkeypatch):
+    """The post-scan auto-apply preference defaults ON, persists both ways, and
+    surfaces in status() — it drives the admin toggle and the scanner guard that
+    keeps a Reset from being undone by the next scan."""
+    import soniqboom.config as cfg
+    mem: dict = {}
+    monkeypatch.setattr(cfg, "load_prefs", lambda: dict(mem))
+    monkeypatch.setattr(cfg, "save_prefs", lambda d: (mem.clear(), mem.update(d)))
+    assert demozoo.auto_apply_enabled() is True          # default ON
+    demozoo.set_auto_apply(False)                        # Reset turns it off
+    assert demozoo.auto_apply_enabled() is False
+    assert demozoo.status()["auto_apply"] is False
+    demozoo.set_auto_apply(True)                         # Apply turns it back on
+    assert demozoo.auto_apply_enabled() is True

--- a/tests/test_detach_render.py
+++ b/tests/test_detach_render.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 S.F. Cyris
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""The blocking render path (get_or_render — Subsonic/DLNA/cast + web spillover)
+must FINISH and cache an in-flight render even when the calling request is
+cancelled by a client disconnect, so the next play is a cache hit instead of a
+re-render."""
+import asyncio
+
+import pytest
+
+from soniqboom.core import conversion_cache as cc
+
+
+@pytest.mark.asyncio
+async def test_detached_render_survives_caller_cancel(tmp_data_dir, tmp_path):
+    started = asyncio.Event()
+
+    async def render_fn():
+        started.set()
+        await asyncio.sleep(0.4)                      # still rendering when we cancel
+        p = tmp_path / "out.wav"
+        p.write_bytes(b"RIFF\x00\x00\x00\x00WAVEdata" + b"\x00" * 8000)
+        return p
+
+    caller = asyncio.ensure_future(cc.get_or_render(
+        track_id="t1", format_type="tracker", subsong=0, render_fn=render_fn))
+    await asyncio.wait_for(started.wait(), timeout=2)
+    caller.cancel()                                   # client disconnected mid-render
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    # The detached render should complete and populate the cache anyway.
+    key = cc._cache_key("t1", "tracker", 0)
+    for _ in range(20):                               # up to ~1s
+        await asyncio.sleep(0.05)
+        cached = await cc.get_cached(key)
+        if cached:
+            break
+    assert cached is not None and cached.exists(), "render was lost on caller cancel"
+
+
+@pytest.mark.asyncio
+async def test_normal_render_still_returns_and_caches(tmp_data_dir, tmp_path):
+    async def render_fn():
+        p = tmp_path / "n.wav"
+        p.write_bytes(b"RIFF\x00\x00\x00\x00WAVEdata" + b"\x00" * 8000)
+        return p
+
+    dest, hit = await cc.get_or_render(
+        track_id="t2", format_type="tracker", subsong=0, render_fn=render_fn)
+    assert hit is False and dest.exists()
+    # second call is a cache hit, no re-render
+    dest2, hit2 = await cc.get_or_render(
+        track_id="t2", format_type="tracker", subsong=0,
+        render_fn=lambda: (_ for _ in ()).throw(AssertionError("should not re-render")))
+    assert hit2 is True and dest2 == dest

--- a/tests/test_year_provenance.py
+++ b/tests/test_year_provenance.py
@@ -72,6 +72,39 @@ def test_carry_no_provenance_lets_file_year_win():
     assert new.get("year_source") in (None, "")
 
 
+def test_carry_user_edited_fields_survive_rescan():
+    """Store-only metadata edits (non-taggable formats) carry across a rescan's
+    fresh file extract; year still rides its own provenance."""
+    old = {"artist": "OldFile", "title": "Real Title", "composer": "P. Hajba",
+           "user_edited": ["title", "composer"]}
+    new = {"artist": "OldFile", "title": "mojibake�", "composer": ""}
+    _carry_enrichment(old, new)
+    assert new["title"] == "Real Title"
+    assert new["composer"] == "P. Hajba"
+    assert new["user_edited"] == ["title", "composer"]
+
+
+def test_carry_edited_artist_does_not_drop_enrichment():
+    """Regression (QA round 2): hand-editing the Artist via the store-only editor
+    must NOT drop the track's scene_group / demozoo year on the next rescan.  The
+    edited artist is restored BEFORE the identity check, so same_artist compares
+    the user's corrected value against itself (True) rather than the file's stale
+    demoscene handle — otherwise the very act of fixing the artist wiped the
+    enrichment that motivated opening the editor."""
+    old = {"artist": "Matthew Simmonds", "file_md5": "m1",
+           "user_edited": ["artist"],
+           "scene_group": "Anarchy", "scene_path": "MOD/4mat/x.mod",
+           "year": 1991, "year_source": "demozoo", "year_file": None}
+    new = {"artist": "4-mat", "file_md5": "m1",      # file still holds the handle
+           "scene_group": None, "scene_path": None, "year": None}
+    _carry_enrichment(old, new)
+    assert new["artist"] == "Matthew Simmonds"       # hand edit restored
+    assert new["scene_group"] == "Anarchy"           # …and enrichment KEPT
+    assert new["scene_path"] == "MOD/4mat/x.mod"
+    assert new["year"] == 1991 and new["year_source"] == "demozoo"
+    assert new["user_edited"] == ["artist"]
+
+
 def test_carry_is_idempotent_on_replay():
     """Replaying an already-merged record (AOF replay) changes nothing."""
     old = {"artist": "A", "year": 1994, "year_source": "demozoo", "year_file": 1986}


### PR DESCRIPTION
- **Restore SID & tracker-module playback on macOS (accurate reSIDfp engine).** Rebuild the SID renderer chain (libresidfp → libsidplayfp → sidplayfp) and zxtune from source and bundle their libraries self-contained, so playback no longer breaks after a Homebrew upgrade.

- **Renderer health validation, clearer playback errors, and install tooling.** Validate all audio renderers at startup; when a track's renderer is missing or broken, return an actionable error instead of a generic failure. Adds `install.sh --clean` / `--rebuild` and a `startup.sh` launcher (documented in the README).

- **SCENE tab: identify composers for untagged scene modules (title-first Demozoo lookup).** For modules that carry only a song title, resolve the composer and crew on Demozoo, store both in the library so they're searchable by author and by group, and link the matching scene release page.

- **Fix SCENE tab failing to identify known scene composers.** Artist handles that are Demozoo aliases (e.g. "Purple Motion") or in "Real Name (Handle)" form now resolve instead of showing "no demoscene entry found"; the composer credit parser no longer mis-attributes graphics / rip / conversion credits as the composer; and stray empty-quote and empty "More by" rendering on the panel are corrected.

- **Reset Demozoo enrichment (new admin control).** One-click removal of auto-added release years, scene groups, and composers — preserving your own tag edits — with a toggle to keep enrichment off after a reset (instead of a scan re-applying it).
